### PR TITLE
Added feature: tissue requests, modified: download_data

### DIFF
--- a/mbtb_app/db/schema.sql
+++ b/mbtb_app/db/schema.sql
@@ -171,5 +171,5 @@ CREATE TABLE tissue_requests(
     source_of_funding text DEFAULT NULL,
     abstract text DEFAULT NULL,
     pending_approval enum('Y','N') DEFAULT 'Y',
-    PRIMARY KEY (tissue_requests_id),
+    PRIMARY KEY (tissue_requests_id)
 ) ENGINE=InnoDB DEFAULT CHARSET=UTF8MB4;

--- a/mbtb_app/db/schema.sql
+++ b/mbtb_app/db/schema.sql
@@ -171,5 +171,9 @@ CREATE TABLE tissue_requests(
     source_of_funding text DEFAULT NULL,
     abstract text DEFAULT NULL,
     pending_approval enum('Y','N') DEFAULT 'Y',
+    received_date date DEFAULT NULL,
+    approval_date date DEFAULT NULL,
+    archived_date date DEFAULT NULL,
+    tissue_request_number varchar(255) DEFAULT NULL,
     PRIMARY KEY (tissue_requests_id)
 ) ENGINE=InnoDB DEFAULT CHARSET=UTF8MB4;

--- a/mbtb_app/db/schema.sql
+++ b/mbtb_app/db/schema.sql
@@ -15,7 +15,7 @@ CREATE TABLE users(
     province varchar(255) DEFAULT NULL,
     country varchar(255) DEFAULT NULL,
     postal_code varchar(255) DEFAULT NULL,
-    comments varchar(255) DEFAULT NULL,
+    comments text DEFAULT NULL,
     active_since date DEFAULT NULL,
     pending_approval enum('Y','N') DEFAULT 'Y',
     PRIMARY KEY (id),
@@ -152,4 +152,24 @@ CREATE TABLE other_details(
     FOREIGN KEY (autopsy_type_id)
         REFERENCES autopsy_types(autopsy_type_id)
         ON DELETE no action
+) ENGINE=InnoDB DEFAULT CHARSET=UTF8MB4;
+
+CREATE TABLE tissue_requests(
+    tissue_requests_id int unsigned NOT NULL AUTO_INCREMENT,
+    title varchar(10) DEFAULT NULL,
+    first_name varchar(255) DEFAULT NULL,
+    last_name varchar(255) DEFAULT NULL,
+    email varchar(255) NOT NULL DEFAULT '',
+    institution varchar(255) DEFAULT NULL,
+    department_name varchar(255) DEFAULT NULL,
+    city varchar(255) DEFAULT NULL,
+    province varchar(255) DEFAULT NULL,
+    postal_code varchar(255) DEFAULT NULL,
+    phone_number varchar(255) DEFAULT NULL,
+    fax_number varchar(255) DEFAULT NULL,
+    project_title text DEFAULT NULL,
+    source_of_funding text DEFAULT NULL,
+    abstract text DEFAULT NULL,
+    pending_approval enum('Y','N') DEFAULT 'Y',
+    PRIMARY KEY (tissue_requests_id),
 ) ENGINE=InnoDB DEFAULT CHARSET=UTF8MB4;

--- a/mbtb_app/db/schema.sql
+++ b/mbtb_app/db/schema.sql
@@ -173,7 +173,7 @@ CREATE TABLE tissue_requests(
     pending_approval enum('Y','N') DEFAULT 'Y',
     received_date date DEFAULT NULL,
     approval_date date DEFAULT NULL,
-    archived_date date DEFAULT NULL,
+    reverted_date date DEFAULT NULL,
     tissue_request_number varchar(255) DEFAULT NULL,
     PRIMARY KEY (tissue_requests_id)
 ) ENGINE=InnoDB DEFAULT CHARSET=UTF8MB4;

--- a/mbtb_app/db/schema.sql
+++ b/mbtb_app/db/schema.sql
@@ -87,7 +87,7 @@ INSERT INTO tissue_types(tissue_type) VALUES
 
 CREATE TABLE prime_details(
     prime_details_id int unsigned NOT NULL AUTO_INCREMENT,
-    mbtb_code varchar(255) NOT NULL,
+    mbtb_code varchar(255) NOT NULL UNIQUE,
     sex enum('Male', 'Female') DEFAULT NULL,
     age varchar(50) DEFAULT NULL,
     postmortem_interval varchar(255) DEFAULT NULL,

--- a/mbtb_app/resources/apis/data/data/envs/development.py
+++ b/mbtb_app/resources/apis/data/data/envs/development.py
@@ -39,6 +39,7 @@ INSTALLED_APPS = [
     'django.contrib.staticfiles',
     'rest_framework',
     'mbtb',
+    'tissue_requests'
 ]
 
 MIDDLEWARE = [

--- a/mbtb_app/resources/apis/data/data/urls.py
+++ b/mbtb_app/resources/apis/data/data/urls.py
@@ -5,5 +5,6 @@ from django.urls import path, include
 urlpatterns = [
     path('admin/', admin.site.urls),
     path('', include('mbtb.urls')),
+    path('', include('tissue_requests.urls')),
 
 ]

--- a/mbtb_app/resources/apis/data/mbtb/db_operations/download_all_data.py
+++ b/mbtb_app/resources/apis/data/mbtb/db_operations/download_all_data.py
@@ -1,0 +1,26 @@
+from ..models import OtherDetails
+from ..serializers import OtherDetailsSerializer
+
+
+# This class is to download all mbtb data without prime_details_id, other_details_id as a list of dict
+class DownloadAllData(object):
+
+    def __init__(self):
+        pass
+
+    def run(self):
+        _other_details_response = OtherDetails.objects.all().select_related()
+        _serializer_response = OtherDetailsSerializer(_other_details_response, many=True)
+
+        # Converting OrderedDict to list of list
+        _serializer_response = [dict(elem) for elem in _serializer_response.data]
+
+        if (len(_serializer_response) is 0):
+            return {'response': False}
+
+        # Removing primary keys from data
+        for elem in _serializer_response:
+            del elem['prime_details_id']
+            del elem['other_details_id']
+
+        return {'response': True, 'data': _serializer_response}

--- a/mbtb_app/resources/apis/data/mbtb/db_operations/download_filtered_data.py
+++ b/mbtb_app/resources/apis/data/mbtb/db_operations/download_filtered_data.py
@@ -1,0 +1,29 @@
+from ..models import OtherDetails
+from ..serializers import OtherDetailsSerializer
+
+
+# This class is download filtered mbtb data based on given mbtb_code as a list of dict.
+# It doesn't include prime_details_id, other_details_id.
+class DownloadFilteredData(object):
+
+    def __init__(self):
+        pass
+
+    def run(self, **kwargs):
+        _mbtb_code_list = kwargs.get('input_mbtb_codes', None)
+        _other_details_response = OtherDetails.objects.filter(
+            prime_details_id__mbtb_code__in=_mbtb_code_list).select_related()
+        _serializer_response = OtherDetailsSerializer(_other_details_response, many=True)
+
+        # Converting OrderedDict to list of Dict
+        _serializer_response = [dict(elem) for elem in _serializer_response.data]
+
+        if (len(_serializer_response) is 0) or not(len(_serializer_response) == len(_mbtb_code_list)):
+            return {'response': False}
+
+        # Removing primary keys from data
+        for elem in _serializer_response:
+            del elem['prime_details_id']
+            del elem['other_details_id']
+
+        return {'response': True, 'data': _serializer_response}

--- a/mbtb_app/resources/apis/data/mbtb/models.py
+++ b/mbtb_app/resources/apis/data/mbtb/models.py
@@ -16,7 +16,7 @@ class AutopsyTypes(models.Model):
 
 class PrimeDetails(models.Model):
     prime_details_id = models.AutoField(primary_key=True)
-    mbtb_code = models.CharField(max_length=50)
+    mbtb_code = models.CharField(max_length=50, unique=True)
     sex = models.CharField(max_length=6, blank=True, null=True)
     age = models.CharField(max_length=50, blank=True, null=True)
     postmortem_interval = models.CharField(max_length=255, blank=True, null=True)

--- a/mbtb_app/resources/apis/data/mbtb/permissions/is_admin.py
+++ b/mbtb_app/resources/apis/data/mbtb/permissions/is_admin.py
@@ -23,7 +23,7 @@ class IsAdmin(permissions.BasePermission):
             return False
 
         if request.method == 'PATCH':
-            valid_url = ['edit_data']
+            valid_url = ['edit_data', 'file_upload']
 
             # splitting url e.g. /edit_data/1/ to get brain_dataset for comparison
             url_path = request.path.split('/')

--- a/mbtb_app/resources/apis/data/mbtb/permissions/is_admin.py
+++ b/mbtb_app/resources/apis/data/mbtb/permissions/is_admin.py
@@ -23,7 +23,7 @@ class IsAdmin(permissions.BasePermission):
             return False
 
         if request.method == 'PATCH':
-            valid_url = ['edit_data', 'file_upload']
+            valid_url = ['edit_data', 'file_upload', 'get_new_tissue_requests']
 
             # splitting url e.g. /edit_data/1/ to get brain_dataset for comparison
             url_path = request.path.split('/')
@@ -44,6 +44,18 @@ class IsAdmin(permissions.BasePermission):
                 return admin
 
             # deny DELETE request if url is not in valid_url by default
+            return False
+
+        if request.method == 'GET':
+            valid_url = ['get_new_tissue_requests', 'get_archive_tissue_requests']
+
+            # splitting url e.g. /get_new_tissue_requests/1/ to get brain_dataset for comparison
+            url_path = request.path.split('/')
+            if max(url_path) in valid_url:
+                admin = self.authenticate(request)
+                return admin
+
+            # deny GET request if url is not in valid_url by default
             return False
 
         raise exceptions.MethodNotAllowed(method=request.method)

--- a/mbtb_app/resources/apis/data/mbtb/permissions/is_admin.py
+++ b/mbtb_app/resources/apis/data/mbtb/permissions/is_admin.py
@@ -23,7 +23,7 @@ class IsAdmin(permissions.BasePermission):
             return False
 
         if request.method == 'PATCH':
-            valid_url = ['edit_data', 'file_upload', 'get_new_tissue_requests']
+            valid_url = ['edit_data', 'file_upload', 'get_new_tissue_requests', 'get_archive_tissue_requests']
 
             # splitting url e.g. /edit_data/1/ to get brain_dataset for comparison
             url_path = request.path.split('/')
@@ -35,7 +35,7 @@ class IsAdmin(permissions.BasePermission):
             return False
 
         if request.method == 'DELETE':
-            valid_url = ['delete_data']
+            valid_url = ['delete_data', 'get_new_tissue_requests', 'get_archive_tissue_requests']
 
             # splitting url e.g. /delete_data/1/ to get brain_dataset for comparison
             url_path = request.path.split('/')

--- a/mbtb_app/resources/apis/data/mbtb/permissions/is_authenticated.py
+++ b/mbtb_app/resources/apis/data/mbtb/permissions/is_authenticated.py
@@ -23,7 +23,7 @@ class IsAuthenticated(permissions.BasePermission):
 
         # only allow admin's POST request via authorized token
         if request.method == 'POST':
-            valid_url = ['add_new_tissue_requests']
+            valid_url = ['add_new_tissue_requests', 'download_data']
 
             # splitting url e.g. /brain_dataset/1/ to get brain_dataset for comparison
             url_path = request.path.split('/')

--- a/mbtb_app/resources/apis/data/mbtb/permissions/is_authenticated.py
+++ b/mbtb_app/resources/apis/data/mbtb/permissions/is_authenticated.py
@@ -21,6 +21,18 @@ class IsAuthenticated(permissions.BasePermission):
             # deny GET request if url is not in valid_url by default
             return False
 
+        # only allow admin's POST request via authorized token
+        if request.method == 'POST':
+            valid_url = ['add_new_tissue_requests']
+
+            # splitting url e.g. /brain_dataset/1/ to get brain_dataset for comparison
+            url_path = request.path.split('/')
+            if max(url_path) in valid_url:
+                return self.authenticate(request)
+
+            # deny POST request if url is not in valid_url by default
+            return False
+
         raise exceptions.MethodNotAllowed(method=request.method)
 
     def authenticate(self, request):

--- a/mbtb_app/resources/apis/data/mbtb/tests.py
+++ b/mbtb_app/resources/apis/data/mbtb/tests.py
@@ -602,8 +602,7 @@ class FileUploadAPIViewTest(SetUpTestData):
         self.assertEqual(response_without_token.data['detail'], predicted_msg)
 
     def test_is_number_check(self):
-        self.is_number_check_error['mbtb_code'] = 'test'
-        predicted_msg = 'Expecting value, received text for duration and/or brain_weight.'
+        predicted_msg = 'Expecting value, received text for duration and/or brain_weight at mbtb_code: BB99-103.'
         self.client.credentials(HTTP_AUTHORIZATION='Token ' + self.token.decode('utf-8'))
         resposne_changed_names = self.client.post(
             '/file_upload/', {'file': open('is_number_check_error.csv', 'rb')}, headers={'Content-Type': 'text/csv'}

--- a/mbtb_app/resources/apis/data/mbtb/tests.py
+++ b/mbtb_app/resources/apis/data/mbtb/tests.py
@@ -129,12 +129,12 @@ class PrimeDetailsViewTest(SetUpTestData):
 
     # post request with and without token
     def test_post_request(self):
-        predicted_msg = 'Method "POST" not allowed.'
+        predicted_msg = 'Authentication credentials were not provided.'
         response_without_token = self.client.post('/brain_dataset/1/')
         self.client.credentials(HTTP_AUTHORIZATION='Token ' + self.token.decode('utf-8'))
         response_with_token = self.client.post('/brain_dataset/1/')
-        self.assertEqual(response_with_token.status_code, status.HTTP_405_METHOD_NOT_ALLOWED)
-        self.assertEqual(response_without_token.status_code, status.HTTP_405_METHOD_NOT_ALLOWED)
+        self.assertEqual(response_with_token.status_code, status.HTTP_403_FORBIDDEN)
+        self.assertEqual(response_without_token.status_code, status.HTTP_403_FORBIDDEN)
         self.assertEqual(response_with_token.data['detail'], predicted_msg)
         self.assertEqual(response_without_token.data['detail'], predicted_msg)
 
@@ -208,12 +208,12 @@ class OtherDetailsViewTest(SetUpTestData):
 
     # post request with and without token
     def test_post_request(self):
-        predicted_msg = 'Method "POST" not allowed.'
+        predicted_msg = 'Authentication credentials were not provided.'
         self.client.credentials(HTTP_AUTHORIZATION='Token ' + self.token.decode('utf-8'))
         response_with_token = self.client.post('/other_details/1/')
         response_without_token = self.client.post('/other_details/')
-        self.assertEqual(response_with_token.status_code, status.HTTP_405_METHOD_NOT_ALLOWED)
-        self.assertEqual(response_without_token.status_code, status.HTTP_405_METHOD_NOT_ALLOWED)
+        self.assertEqual(response_with_token.status_code, status.HTTP_403_FORBIDDEN)
+        self.assertEqual(response_without_token.status_code, status.HTTP_403_FORBIDDEN)
         self.assertEqual(response_with_token.data['detail'], predicted_msg)
         self.assertEqual(response_without_token.data['detail'], predicted_msg)
 
@@ -382,12 +382,12 @@ class GetSelectOptionsViewTest(SetUpTestData):
 
     # invalid post request test
     def test_post_request(self):
-        predicted_msg = 'Method "POST" not allowed.'
+        predicted_msg = 'Authentication credentials were not provided.'
         response_without_token = self.client.post('/get_select_options/')
         self.client.credentials(HTTP_AUTHORIZATION='Token ' + self.token.decode('utf-8'))
         response_with_token = self.client.post('/get_select_options/')
-        self.assertEqual(response_with_token.status_code, status.HTTP_405_METHOD_NOT_ALLOWED)
-        self.assertEqual(response_without_token.status_code, status.HTTP_405_METHOD_NOT_ALLOWED)
+        self.assertEqual(response_with_token.status_code, status.HTTP_403_FORBIDDEN)
+        self.assertEqual(response_without_token.status_code, status.HTTP_403_FORBIDDEN)
         self.assertEqual(response_with_token.data['detail'], predicted_msg)
         self.assertEqual(response_without_token.data['detail'], predicted_msg)
 
@@ -573,7 +573,7 @@ class FileUploadAPIViewTest(SetUpTestData):
 
     # invalid get request test
     def test_get_request(self):
-        predicted_msg = 'Method "GET" not allowed.'
+        predicted_msg = 'Authentication credentials were not provided.'
         response_without_token = self.client.get(
             '/file_upload/', {'file': open('file_upload_test.csv', 'rb')}, headers={'Content-Type': 'text/csv'}
         )
@@ -581,8 +581,8 @@ class FileUploadAPIViewTest(SetUpTestData):
         response_with_token = self.client.get(
             '/file_upload/', {'file': open('file_upload_test.csv', 'rb')}, headers={'Content-Type': 'text/csv'}
         )
-        self.assertEqual(response_with_token.status_code, status.HTTP_405_METHOD_NOT_ALLOWED)
-        self.assertEqual(response_without_token.status_code, status.HTTP_405_METHOD_NOT_ALLOWED)
+        self.assertEqual(response_with_token.status_code, status.HTTP_403_FORBIDDEN)
+        self.assertEqual(response_without_token.status_code, status.HTTP_403_FORBIDDEN)
         self.assertEqual(response_with_token.data['detail'], predicted_msg)
         self.assertEqual(response_without_token.data['detail'], predicted_msg)
 
@@ -703,12 +703,12 @@ class EditDataAPIViewTest(SetUpTestData):
         self.client.credentials()
 
     def test_get_request(self):
-        predicted_msg = 'Method "GET" not allowed.'
+        predicted_msg = 'Authentication credentials were not provided.'
         response_without_token = self.client.get(self.url, self.changed_column_names, format='json')
         self.client.credentials(HTTP_AUTHORIZATION='Token ' + self.token.decode('utf-8'))
         response_with_token = self.client.get(self.url, format='json')
-        self.assertEqual(response_with_token.status_code, status.HTTP_405_METHOD_NOT_ALLOWED)
-        self.assertEqual(response_without_token.status_code, status.HTTP_405_METHOD_NOT_ALLOWED)
+        self.assertEqual(response_with_token.status_code, status.HTTP_403_FORBIDDEN)
+        self.assertEqual(response_without_token.status_code, status.HTTP_403_FORBIDDEN)
         self.assertEqual(response_with_token.data['detail'], predicted_msg)
         self.assertEqual(response_without_token.data['detail'], predicted_msg)
 
@@ -797,12 +797,12 @@ class DeleteDataAPIViewTest(SetUpTestData):
         self.client.credentials()
 
     def test_get_request(self):
-        predicted_msg = 'Method "GET" not allowed.'
+        predicted_msg = 'Authentication credentials were not provided.'
         response_without_token = self.client.get(self.url, format='json')
         self.client.credentials(HTTP_AUTHORIZATION='Token ' + self.token.decode('utf-8'))
         response_with_token = self.client.get(self.url, format='json')
-        self.assertEqual(response_with_token.status_code, status.HTTP_405_METHOD_NOT_ALLOWED)
-        self.assertEqual(response_without_token.status_code, status.HTTP_405_METHOD_NOT_ALLOWED)
+        self.assertEqual(response_with_token.status_code, status.HTTP_403_FORBIDDEN)
+        self.assertEqual(response_without_token.status_code, status.HTTP_403_FORBIDDEN)
         self.assertEqual(response_with_token.data['detail'], predicted_msg)
         self.assertEqual(response_without_token.data['detail'], predicted_msg)
 

--- a/mbtb_app/resources/apis/data/mbtb/tests.py
+++ b/mbtb_app/resources/apis/data/mbtb/tests.py
@@ -1,7 +1,6 @@
 from rest_framework import status
 from rest_framework.test import APITestCase, force_authenticate, APIClient
-from .models import PrimeDetails, NeuropathologicalDiagnosis, TissueTypes, AutopsyTypes, OtherDetails
-from .models import AdminAccount
+from .models import PrimeDetails, NeuropathologicalDiagnosis, TissueTypes, AutopsyTypes, OtherDetails, AdminAccount
 from .serializers import PrimeDetailsSerializer, OtherDetailsSerializer, FileUploadPrimeDetailsSerializer, \
     FileUploadOtherDetailsSerializer, InsertRowPrimeDetailsSerializer
 import jwt

--- a/mbtb_app/resources/apis/data/mbtb/urls.py
+++ b/mbtb_app/resources/apis/data/mbtb/urls.py
@@ -15,4 +15,5 @@ urlpatterns = [
     path('file_upload/', views.FileUploadAPIView.as_view()),
     path('edit_data/<int:prime_details_id>/', views.EditDataAPIView.as_view()),
     path('delete_data/<int:prime_details_id>/', views.DeleteDataAPIView.as_view()),
+    path('download_data/', views.DownloadDataAPIView.as_view())
 ]

--- a/mbtb_app/resources/apis/data/mbtb/views.py
+++ b/mbtb_app/resources/apis/data/mbtb/views.py
@@ -126,11 +126,12 @@ class GetSelectOptions(views.APIView):
         })
 
 
-# This view class is to upload data via csv file in prime_details, other_details, allowed methods: POST
+# This view class is to upload and edit data via csv file in prime_details, other_details, allowed methods: POST
 class FileUploadAPIView(views.APIView):
     parser_classes = (MultiPartParser, FormParser)
     permission_classes = [IsAdmin]
 
+    # For `POST` request: upload data via csv file
     def post(self, request, format=None):
         validate_data = ValidateData()
         _file_tag = validate_data.check_file_tag(request=request)  # Check for `file` tag
@@ -183,9 +184,9 @@ class FileUploadAPIView(views.APIView):
                 _brain_weight = validate_data.check_is_number(value=row['brain_weight'])
 
                 if (not _duration['Response']) or (not _brain_weight['Response']):
-                    return response.Response(
-                        {'Error': 'Expecting value, received text for duration and/or brain_weight.'
-                         }, status="400")
+                    _error = 'Expecting value, received text for duration and/or brain_weight at mbtb_code: {}.' \
+                        .format(row['mbtb_code'])
+                    return response.Response({'Error': _error}, status="400")
 
                 # If other_details data is validated then save it else return error response
                 other_details = OtherDetailsTemplate(
@@ -207,6 +208,110 @@ class FileUploadAPIView(views.APIView):
 
                     # deleting instance if any error in other_details data
                     prime_serializer_instance.delete()
+
+                    # Return error response if any error in other_details data
+                    return response.Response(
+                        {'Response': 'Failure',
+                         'Message': 'Error in other details, Data uploading failed at mbtb_code: {}'.format(
+                             row['mbtb_code']), 'Error': other_details_serializer.errors},
+                        status="400"
+                    )
+
+            else:
+                # TODO: log errors here related to file data uploading for prime details
+                # Return error response if any error in prime_details data
+                return response.Response(
+                    {'Response': 'Failure',
+                     'Message': 'Error in prime details, Data uploading failed at mbtb_code: {}'.format(
+                         row['mbtb_code']), 'Error': prime_details_serializer.errors},
+                    status="400"
+                )
+
+        # Return response: data is uploaded successfully
+        return response.Response({'Response': 'Success'}, status="201")
+
+    # For `PATCH` request: edit data via csv file
+    def patch(self, request, format=None):
+        validate_data = ValidateData()
+        _file_tag = validate_data.check_file_tag(request=request)  # Check for `file` tag
+        if not _file_tag['Response']:
+            return response.Response({'Error': _file_tag['Message']}, status="400")
+
+        _file_obj = request.data['file']
+        _file_type = validate_data.check_file_type(filename=str(_file_obj))  # Check for file type
+        if not _file_type['Response']:
+            return response.Response({'Error': _file_type['Message']}, status="400")
+
+        # Converting file data into dictionary
+        _csv_file = csv.DictReader(codecs.iterdecode(_file_obj, 'utf-8-sig'))
+        _csv_file = [dict(row) for row in _csv_file]
+        _file_size = validate_data.check_file_size(csv_file=_csv_file)  # Check file size
+        if not _file_size['Response']:
+            return response.Response({'Error': _file_size['Message']}, status="400")
+
+        _column_names = validate_data.check_column_names(column_names=list(_csv_file[0].keys()))  # Check column names
+        if not _column_names['Response']:
+            return response.Response({'Error': _column_names['Message']}, status="400")
+
+        for row in _csv_file:
+
+            # Get prime_details, other_details based on prime_details_id or return 404 if not found
+            prime_details = get_object_or_404(PrimeDetails, mbtb_code=row['mbtb_code'])
+            other_details = get_object_or_404(OtherDetails, prime_details_id=prime_details.prime_details_id)
+
+            # Get or Create (Get value or create new if not exists) for AutopsyType, TissuType and Neuro Diagnosis
+            tissue_type = GetOrCreate(model_name='TissueTypes').run(tissue_type=row['tissue_type'])
+            neuro_diagnosis_id = GetOrCreate(model_name='NeuropathologicalDiagnosis').run(
+                neuro_diagnosis_name=row['neuropathology_diagnosis'])
+            autopsy_type = GetOrCreate(model_name='AutopsyTypes').run(autopsy_type=row['autopsy_type'])
+
+            # If prime_details data is validated then save it else return error response
+            _preservation_method = validate_data.check_preservation_method(
+                formalin_fixed=row['formalin_fixed'], fresh_frozen=row['fresh_frozen']
+            )
+            prime_details_template_data = PrimeDetailsTemplate(
+                mbtb_code=row['mbtb_code'], sex=row['sex'], age=row['age'],
+                postmortem_interval=row['postmortem_interval'], time_in_fix=row['time_in_fix'],
+                clinical_diagnosis=row['clinical_diagnosis'], tissue_type=tissue_type.tissue_type_id,
+                preservation_method=_preservation_method,
+                neuro_diagnosis_id=neuro_diagnosis_id.neuro_diagnosis_id,
+                storage_year=row['storage_year']
+            )
+            prime_details_serializer = FileUploadPrimeDetailsSerializer(
+                prime_details, data=prime_details_template_data.__dict__, partial=True
+            )
+
+            if prime_details_serializer.is_valid():
+                prime_details_serializer.save()  # Saving prime_details
+
+                # If other_details data is validated then save it else return error response
+                _duration = validate_data.check_is_number(value=row['duration'])
+                _brain_weight = validate_data.check_is_number(value=row['brain_weight'])
+
+                if (not _duration['Response']) or (not _brain_weight['Response']):
+                    _error = 'Expecting value, received text for duration and/or brain_weight at mbtb_code: {}.'\
+                        .format(row['mbtb_code'])
+                    return response.Response({'Error': _error}, status="400")
+
+                # If other_details data is validated then save it else return error response
+                other_details_template_data = OtherDetailsTemplate(
+                    prime_details_id=prime_details.prime_details_id, race=row['race'],
+                    duration=_duration['Value'], clinical_details=row['clinical_details'],
+                    cause_of_death=row['cause_of_death'], brain_weight=_brain_weight['Value'],
+                    neuropathology_summary=row['neuropathology_summary'],
+                    neuropathology_gross=row['neuropathology_gross'],
+                    neuropathology_microscopic=row['neuropathology_microscopic'], cerad=row['cerad'],
+                    braak_stage=row['braak_stage'], khachaturian=row['khachaturian'], abc=row['abc'],
+                    autopsy_type=autopsy_type.autopsy_type_id, formalin_fixed=row['formalin_fixed'],
+                    fresh_frozen=row['fresh_frozen']
+                )
+                other_details_serializer = FileUploadOtherDetailsSerializer(
+                    other_details, data=other_details_template_data.__dict__, partial=True
+                )
+                if other_details_serializer.is_valid():
+                    other_details_serializer.save()  # Saving other_details
+                else:
+                    # TODO: log errors here related to file data uploading for other details
 
                     # Return error response if any error in other_details data
                     return response.Response(

--- a/mbtb_app/resources/apis/data/mbtb/views.py
+++ b/mbtb_app/resources/apis/data/mbtb/views.py
@@ -183,7 +183,9 @@ class FileUploadAPIView(views.APIView):
                 _brain_weight = validate_data.check_is_number(value=row['brain_weight'])
 
                 if (not _duration['Response']) or (not _brain_weight['Response']):
-                    return response.Response({'Error': 'Expecting value, received text for duration and/or brain_weight.'}, status="400")
+                    return response.Response(
+                        {'Error': 'Expecting value, received text for duration and/or brain_weight.'
+                         }, status="400")
 
                 # If other_details data is validated then save it else return error response
                 other_details = OtherDetailsTemplate(

--- a/mbtb_app/resources/apis/data/tissue_requests/admin.py
+++ b/mbtb_app/resources/apis/data/tissue_requests/admin.py
@@ -1,0 +1,3 @@
+from django.contrib import admin
+
+# Register your models here.

--- a/mbtb_app/resources/apis/data/tissue_requests/apps.py
+++ b/mbtb_app/resources/apis/data/tissue_requests/apps.py
@@ -1,0 +1,5 @@
+from django.apps import AppConfig
+
+
+class TissueRequestsConfig(AppConfig):
+    name = 'tissue_requests'

--- a/mbtb_app/resources/apis/data/tissue_requests/models.py
+++ b/mbtb_app/resources/apis/data/tissue_requests/models.py
@@ -12,12 +12,16 @@ class TissueRequests(models.Model):
     city = models.CharField(max_length=30)
     province = models.CharField(max_length=30)
     postal_code = models.CharField(max_length=10)
-    phone_number = models.CharField(max_length=20, blank=True)
-    fax_number = models.CharField(max_length=20, blank=True)
+    phone_number = models.CharField(max_length=20, null=True)
+    fax_number = models.CharField(max_length=20, null=True)
     project_title = models.TextField()
     source_of_funding = models.TextField()
     abstract = models.TextField()
     pending_approval = models.CharField(max_length=1, default='Y')
+    received_date = models.DateField(null=True)
+    approval_date = models.DateField(null=True)
+    reverted_date = models.DateField(null=True)
+    tissue_request_number = models.CharField(max_length=15, null=True)
 
     class Meta:
         managed = False

--- a/mbtb_app/resources/apis/data/tissue_requests/models.py
+++ b/mbtb_app/resources/apis/data/tissue_requests/models.py
@@ -1,3 +1,4 @@
+import uuid
 from django.db import models
 
 
@@ -21,7 +22,7 @@ class TissueRequests(models.Model):
     received_date = models.DateField(null=True)
     approval_date = models.DateField(null=True)
     reverted_date = models.DateField(null=True)
-    tissue_request_number = models.CharField(max_length=15, null=True)
+    tissue_request_number = models.CharField(max_length=15, unique=True, default=uuid.uuid4)
 
     class Meta:
         managed = False

--- a/mbtb_app/resources/apis/data/tissue_requests/models.py
+++ b/mbtb_app/resources/apis/data/tissue_requests/models.py
@@ -22,7 +22,7 @@ class TissueRequests(models.Model):
     received_date = models.DateField(null=True)
     approval_date = models.DateField(null=True)
     reverted_date = models.DateField(null=True)
-    tissue_request_number = models.CharField(max_length=15, unique=True, default=uuid.uuid4)
+    tissue_request_number = models.CharField(max_length=40, unique=True, default=uuid.uuid4)
 
     class Meta:
         managed = False

--- a/mbtb_app/resources/apis/data/tissue_requests/models.py
+++ b/mbtb_app/resources/apis/data/tissue_requests/models.py
@@ -23,5 +23,5 @@ class TissueRequests(models.Model):
         managed = False
         db_table = 'tissue_requests'
 
-    def __str__(self):
+    def __int__(self):
         return self.tissue_requests_id

--- a/mbtb_app/resources/apis/data/tissue_requests/models.py
+++ b/mbtb_app/resources/apis/data/tissue_requests/models.py
@@ -22,3 +22,6 @@ class TissueRequests(models.Model):
     class Meta:
         managed = False
         db_table = 'tissue_requests'
+
+    def __str__(self):
+        return self.tissue_requests_id

--- a/mbtb_app/resources/apis/data/tissue_requests/models.py
+++ b/mbtb_app/resources/apis/data/tissue_requests/models.py
@@ -1,0 +1,24 @@
+from django.db import models
+
+
+class TissueRequests(models.Model):
+    tissue_requests_id = models.AutoField(primary_key=True)
+    title = models.CharField(max_length=10, blank=True)
+    first_name = models.CharField(max_length=30)
+    last_name = models.CharField(max_length=30)
+    email = models.EmailField()
+    institution = models.TextField()
+    department_name = models.TextField()
+    city = models.CharField(max_length=30)
+    province = models.CharField(max_length=30)
+    postal_code = models.CharField(max_length=10)
+    phone_number = models.CharField(max_length=20, blank=True)
+    fax_number = models.CharField(max_length=20, blank=True)
+    project_title = models.TextField()
+    source_of_funding = models.TextField()
+    abstract = models.TextField()
+    pending_approval = models.CharField(max_length=1, default='Y')
+
+    class Meta:
+        managed = False
+        db_table = 'tissue_requests'

--- a/mbtb_app/resources/apis/data/tissue_requests/serializers.py
+++ b/mbtb_app/resources/apis/data/tissue_requests/serializers.py
@@ -1,0 +1,9 @@
+from rest_framework import serializers
+from .models import TissueRequests
+
+
+class TissueRequestsSerializer(serializers.ModelSerializer):
+
+    class Meta:
+        model = TissueRequests
+        fields = '__all__'

--- a/mbtb_app/resources/apis/data/tissue_requests/tests.py
+++ b/mbtb_app/resources/apis/data/tissue_requests/tests.py
@@ -11,7 +11,7 @@ class SetUpTestData(APITestCase):
 
     @classmethod
     def setUpClass(cls):
-        cls.test_data = {
+        cls.test_data_1 = {
             "first_name": "test",
             "last_name": "test",
             "email": "test@gmail.com",
@@ -23,98 +23,177 @@ class SetUpTestData(APITestCase):
             "project_title": "mbtb_app",
             "source_of_funding": "dal",
             "abstract": "test"
-        }
-        cls.model_response = TissueRequests.objects.create(**cls.test_data)
-        # Admin Authentication: generate temp account and token
-        cls.email = 'admin@mbtb.ca'
-        cls.password = 'asdfghjkl123'
-        AdminAccount.objects.create(email=cls.email, password_hash=cls.password)
-        admin = AdminAccount.objects.get(email=cls.email)
-        payload = {
+        }  # For get new requests tests
+        cls.test_data_2 = cls.test_data_1.copy()  # For get archive list tests
+        cls.test_data_2['pending_approval'] = 'N'
+        cls.model_response_1 = TissueRequests.objects.create(**cls.test_data_1)
+        cls.model_response_2 = TissueRequests.objects.create(**cls.test_data_2)
+        
+        # Admin Authentication: generate temp account and admin_token
+        cls.admin_email = 'admin@mbtb.ca'
+        cls.admin_password = 'asdfghjkl123'
+        AdminAccount.objects.create(email=cls.admin_email, password_hash=cls.admin_password)
+        admin = AdminAccount.objects.get(email=cls.admin_email)
+        admin_payload = {
             'id': admin.id,
             'email': admin.email,
         }
-        cls.token = jwt.encode(payload, "SECRET_KEY", algorithm='HS256')  # generating jwt token
-        cls.client = APIClient(enforce_csrf_checks=True)  # enforcing csrf checks
+        cls.admin_token = jwt.encode(admin_payload, "SECRET_KEY", algorithm='HS256')  # generating jwt admin_token
+        cls.admin_client = APIClient(enforce_csrf_checks=True)  # enforcing csrf checks
+
+        # User Account: for adding new tissue request, generating temp account and user token
+        cls.user_email = 'user@mbtb.ca'
+        cls.user_password = 'asdfghjkl1234'
+        UserAccount.objects.create(email=cls.user_email, password_hash=cls.user_password)
+        user = UserAccount.objects.get(email=cls.user_email)
+        user_payload = {
+            'id': user.id,
+            'email': user.email,
+        }
+        cls.user_token = jwt.encode(user_payload, "SECRET_KEY", algorithm='HS256')  # generating jwt admin_token
+        cls.user_client = APIClient(enforce_csrf_checks=True)  # enforcing csrf checks
 
     @classmethod
     def tearDownClass(cls):
-        pass
+        TissueRequests.objects.all().delete()
+        AdminAccount.objects.all().delete()
+        UserAccount.objects.all().delete()
 
 
+# This class is to test PostNewTissueRequestsView as a user.
+# Default: post request is allowed, and rest of them are blocked.
 class PostNewTissueRequestsViewTest(SetUpTestData):
 
     def setUp(cls):
         super(SetUpTestData, cls).setUpClass()
+        cls.invalid_payload = cls.test_data_1.copy()
+        cls.invalid_payload['email'] = None
+
+    # Valid post request
+    def test_valid_new_request(self):
+        self.user_client.credentials(HTTP_AUTHORIZATION='Token ' + self.user_token.decode('utf-8'))
+        response = self.user_client.post('/add_new_tissue_requests/', self.test_data_1, format='json')
+        self.assertEquals(response.status_code, status.HTTP_201_CREATED)
+        model_response = TissueRequests.objects.filter(pending_approval='Y')
+        self.assertEqual(len(model_response), 2)
+        self.client.credentials()
+
+    # Invalid post request
+    def test_invalid_new_request(self):
+        predicted_msg = 'This field may not be null.'
+        self.user_client.credentials(HTTP_AUTHORIZATION='Token ' + self.user_token.decode('utf-8'))
+        response = self.user_client.post('/add_new_tissue_requests/', self.invalid_payload, format='json')
+        self.assertEquals(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(response.data['email'][0], predicted_msg)
+        model_response = TissueRequests.objects.filter(pending_approval='Y')
+        self.assertEqual(len(model_response), 1)
+        self.client.credentials()
+
+    # Test: invalid get request
+    def test_get_request(self):
+        predicted_msg = 'Authentication credentials were not provided.'
+        self.user_client.credentials(HTTP_AUTHORIZATION='Token ' + self.user_token.decode('utf-8'))
+        response = self.user_client.get('/add_new_tissue_requests/', format='json')
+        self.assertEquals(response.status_code, status.HTTP_403_FORBIDDEN)
+        self.assertEqual(response.data['detail'], predicted_msg)
+        self.client.credentials()
+
+    # Test: invalid patch request
+    def test_patch_request(self):
+        predicted_msg = 'Method "PATCH" not allowed.'
+        self.user_client.credentials(HTTP_AUTHORIZATION='Token ' + self.user_token.decode('utf-8'))
+        response = self.user_client.patch('/add_new_tissue_requests/', self.test_data_1, format='json')
+        self.assertEquals(response.status_code, status.HTTP_405_METHOD_NOT_ALLOWED)
+        self.assertEqual(response.data['detail'], predicted_msg)
+        self.client.credentials()
+
+    # Test: invalid delete request
+    def test_delete_request(self):
+        predicted_msg = 'Method "DELETE" not allowed.'
+        self.user_client.credentials(HTTP_AUTHORIZATION='Token ' + self.user_token.decode('utf-8'))
+        response = self.user_client.delete('/add_new_tissue_requests/', format='json')
+        self.assertEquals(response.status_code, status.HTTP_405_METHOD_NOT_ALLOWED)
+        self.assertEqual(response.data['detail'], predicted_msg)
+        self.client.credentials()
 
     def tearDown(cls):
         super(SetUpTestData, cls).tearDownClass()
 
 
+# This class is to test GetNewTissueRequestsView as an admin.
+# Default: get request is allowed, and rest of them are blocked.
 class GetNewTissueRequestsViewTest(SetUpTestData):
 
     def setUp(cls):
         super(SetUpTestData, cls).setUpClass()
 
+    # Valid get request to fetch all new tissue requests
     def test_get_all_new_tissue_request(self):
-        self.client.credentials(HTTP_AUTHORIZATION='Token ' + self.token.decode('utf-8'))
-        response = self.client.get('/get_new_tissue_requests/')
-        model_response = TissueRequests.objects.all()
+        self.admin_client.credentials(HTTP_AUTHORIZATION='Token ' + self.admin_token.decode('utf-8'))
+        response = self.admin_client.get('/get_new_tissue_requests/')
+        model_response = TissueRequests.objects.filter(pending_approval='Y')
         serializer_response = TissueRequestsSerializer(model_response, many=True)
         self.assertEqual(response.data, serializer_response.data)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.client.credentials()
+        self.admin_client.credentials()
 
+    # Test: invalid get request
     def test_invalid_request(self):
         predicted_msg = 'Invalid input. Only `Token` tag is allowed.'
-        response = self.client.get('/get_new_tissue_requests/')
+        response = self.admin_client.get('/get_new_tissue_requests/')
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
         self.assertEqual(response.data['detail'], predicted_msg)
 
+    # Valid get request to fetch new single tissue requests
     def test_get_single_tissue_request(self):
-        url = '/get_new_tissue_requests/' + str(self.model_response.pk) + '/'
-        self.client.credentials(HTTP_AUTHORIZATION='Token ' + self.token.decode('utf-8'))
-        response = self.client.get(url)
-        model_response = TissueRequests.objects.get(pk=self.model_response.pk)
+        url = '/get_new_tissue_requests/' + str(self.model_response_1.pk) + '/'
+        self.admin_client.credentials(HTTP_AUTHORIZATION='Token ' + self.admin_token.decode('utf-8'))
+        response = self.admin_client.get(url)
+        model_response = TissueRequests.objects.get(pk=self.model_response_1.pk)
         serializer_response = TissueRequestsSerializer(model_response)
         self.assertEqual(response.data, serializer_response.data)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.client.credentials()
+        self.admin_client.credentials()
 
+    # Invalid get single tissue request
     def test_get_invalid_single_request(self):
         url = '/get_new_tissue_requests/' + '25' + '/'
-        self.client.credentials(HTTP_AUTHORIZATION='Token ' + self.token.decode('utf-8'))
-        response = self.client.get(url)
+        self.admin_client.credentials(HTTP_AUTHORIZATION='Token ' + self.admin_token.decode('utf-8'))
+        response = self.admin_client.get(url)
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
-        self.client.credentials()
+        self.admin_client.credentials()
 
+    # Test: request with empty token
     def test_get_request_with_empty_token(self):
-        self.client.credentials(HTTP_AUTHORIZATION='Token ' + '')
-        response_with_token = self.client.get('/get_new_tissue_requests/')
+        self.admin_client.credentials(HTTP_AUTHORIZATION='Token ' + '')
+        response_with_token = self.admin_client.get('/get_new_tissue_requests/')
         self.assertEqual(response_with_token.status_code, status.HTTP_403_FORBIDDEN)
 
+    # Test: request with invalid token header
     def test_get_request_with_invalid_token_header(self):
         predicted_msg = 'Invalid token header'
-        self.client.credentials(HTTP_AUTHORIZATION='Token ' + ' get request with valid token')
-        response_invalid_header = self.client.get('/get_new_tissue_requests/')
+        self.admin_client.credentials(HTTP_AUTHORIZATION='Token ' + ' get request with valid token')
+        response_invalid_header = self.admin_client.get('/get_new_tissue_requests/')
         self.assertEqual(response_invalid_header.status_code, status.HTTP_403_FORBIDDEN)
         self.assertEqual(response_invalid_header.data['detail'], predicted_msg)
 
+    # Test: invalid post request
     def test_post_request(self):
         predicted_msg = 'Authentication credentials were not provided.'
-        response_without_token = self.client.post('/get_new_tissue_requests/1/')
-        self.client.credentials(HTTP_AUTHORIZATION='Token ' + self.token.decode('utf-8'))
-        response_with_token = self.client.post('/get_new_tissue_requests/1/')
+        response_without_token = self.admin_client.post('/get_new_tissue_requests/1/')
+        self.admin_client.credentials(HTTP_AUTHORIZATION='Token ' + self.admin_token.decode('utf-8'))
+        response_with_token = self.admin_client.post('/get_new_tissue_requests/1/')
         self.assertEqual(response_with_token.status_code, status.HTTP_403_FORBIDDEN)
         self.assertEqual(response_without_token.status_code, status.HTTP_403_FORBIDDEN)
         self.assertEqual(response_with_token.data['detail'], predicted_msg)
         self.assertEqual(response_without_token.data['detail'], predicted_msg)
 
+    # Test: invalid delete request
     def test_delete_request(self):
         predicted_msg = 'Authentication credentials were not provided.'
-        response_without_token = self.client.delete('/get_new_tissue_requests/1/')
-        self.client.credentials(HTTP_AUTHORIZATION='Token ' + self.token.decode('utf-8'))
-        response_with_token = self.client.delete('/get_new_tissue_requests/1/')
+        response_without_token = self.admin_client.delete('/get_new_tissue_requests/1/')
+        self.admin_client.credentials(HTTP_AUTHORIZATION='Token ' + self.admin_token.decode('utf-8'))
+        response_with_token = self.admin_client.delete('/get_new_tissue_requests/1/')
         self.assertEqual(response_with_token.status_code, status.HTTP_403_FORBIDDEN)
         self.assertEqual(response_without_token.status_code, status.HTTP_403_FORBIDDEN)
         self.assertEqual(response_with_token.data['detail'], predicted_msg)
@@ -124,10 +203,84 @@ class GetNewTissueRequestsViewTest(SetUpTestData):
         super(SetUpTestData, cls).tearDownClass()
 
 
+# This class is to test GetArchiveTissueRequestsView as an admin.
+# Default: get request is allowed, and rest of them are blocked.
 class GetArchiveTissueRequestsViewTest(SetUpTestData):
 
     def setUp(cls):
         super(SetUpTestData, cls).setUpClass()
+
+    # Valid get request
+    def test_get_all_new_tissue_request(self):
+        self.admin_client.credentials(HTTP_AUTHORIZATION='Token ' + self.admin_token.decode('utf-8'))
+        response = self.admin_client.get('/get_archive_tissue_requests/')
+        model_response = TissueRequests.objects.filter(pending_approval='N')
+        serializer_response = TissueRequestsSerializer(model_response, many=True)
+        self.assertEqual(response.data, serializer_response.data)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.admin_client.credentials()
+
+    # Test: invalid get request
+    def test_invalid_request(self):
+        predicted_msg = 'Invalid input. Only `Token` tag is allowed.'
+        response = self.admin_client.get('/get_archive_tissue_requests/')
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+        self.assertEqual(response.data['detail'], predicted_msg)
+
+    # Test: valid get single item request
+    def test_get_single_tissue_request(self):
+        url = '/get_archive_tissue_requests/' + str(self.model_response_2.pk) + '/'
+        self.admin_client.credentials(HTTP_AUTHORIZATION='Token ' + self.admin_token.decode('utf-8'))
+        response = self.admin_client.get(url)
+        model_response = TissueRequests.objects.get(pk=self.model_response_2.pk)
+        serializer_response = TissueRequestsSerializer(model_response)
+        self.assertEqual(response.data, serializer_response.data)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.admin_client.credentials()
+
+    # Test: invalid single item request
+    def test_get_invalid_single_request(self):
+        url = '/get_archive_tissue_requests/' + '25' + '/'
+        self.admin_client.credentials(HTTP_AUTHORIZATION='Token ' + self.admin_token.decode('utf-8'))
+        response = self.admin_client.get(url)
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+        self.admin_client.credentials()
+
+    # Test: get request with empty token
+    def test_get_request_with_empty_token(self):
+        self.admin_client.credentials(HTTP_AUTHORIZATION='Token ' + '')
+        response_with_token = self.admin_client.get('/get_archive_tissue_requests/')
+        self.assertEqual(response_with_token.status_code, status.HTTP_403_FORBIDDEN)
+
+    # Test: get request with invalid token header
+    def test_get_request_with_invalid_token_header(self):
+        predicted_msg = 'Invalid token header'
+        self.admin_client.credentials(HTTP_AUTHORIZATION='Token ' + ' get request with valid token')
+        response_invalid_header = self.admin_client.get('/get_archive_tissue_requests/')
+        self.assertEqual(response_invalid_header.status_code, status.HTTP_403_FORBIDDEN)
+        self.assertEqual(response_invalid_header.data['detail'], predicted_msg)
+
+    # Test: post request
+    def test_post_request(self):
+        predicted_msg = 'Authentication credentials were not provided.'
+        response_without_token = self.admin_client.post('/get_archive_tissue_requests/1/')
+        self.admin_client.credentials(HTTP_AUTHORIZATION='Token ' + self.admin_token.decode('utf-8'))
+        response_with_token = self.admin_client.post('/get_archive_tissue_requests/1/')
+        self.assertEqual(response_with_token.status_code, status.HTTP_403_FORBIDDEN)
+        self.assertEqual(response_without_token.status_code, status.HTTP_403_FORBIDDEN)
+        self.assertEqual(response_with_token.data['detail'], predicted_msg)
+        self.assertEqual(response_without_token.data['detail'], predicted_msg)
+
+    # Test: delete request
+    def test_delete_request(self):
+        predicted_msg = 'Authentication credentials were not provided.'
+        response_without_token = self.admin_client.delete('/get_archive_tissue_requests/1/')
+        self.admin_client.credentials(HTTP_AUTHORIZATION='Token ' + self.admin_token.decode('utf-8'))
+        response_with_token = self.admin_client.delete('/get_archive_tissue_requests/1/')
+        self.assertEqual(response_with_token.status_code, status.HTTP_403_FORBIDDEN)
+        self.assertEqual(response_without_token.status_code, status.HTTP_403_FORBIDDEN)
+        self.assertEqual(response_with_token.data['detail'], predicted_msg)
+        self.assertEqual(response_without_token.data['detail'], predicted_msg)
 
     def tearDown(cls):
         super(SetUpTestData, cls).tearDownClass()

--- a/mbtb_app/resources/apis/data/tissue_requests/tests.py
+++ b/mbtb_app/resources/apis/data/tissue_requests/tests.py
@@ -188,7 +188,7 @@ class GetNewTissueRequestsViewTest(SetUpTestData):
         self.assertEqual(response_with_token.data['detail'], predicted_msg)
         self.assertEqual(response_without_token.data['detail'], predicted_msg)
 
-    # Test: invalid delete request
+    # Test: valid delete request
     def test_delete_request(self):
         predicted_msg_1 = 'Not found.'
         predicted_msg_2 = 'Invalid input. Only `Token` tag is allowed.'
@@ -200,6 +200,8 @@ class GetNewTissueRequestsViewTest(SetUpTestData):
         self.assertEqual(response_with_token.data['detail'], predicted_msg_1)
         self.assertEqual(response_without_token.data['detail'], predicted_msg_2)
 
+    # ToDo: write tests for patch request
+    
     def tearDown(cls):
         super(SetUpTestData, cls).tearDownClass()
 
@@ -283,6 +285,8 @@ class GetArchiveTissueRequestsViewTest(SetUpTestData):
         self.assertEqual(response_without_token.status_code, status.HTTP_403_FORBIDDEN)
         self.assertEqual(response_with_token.data['detail'], predicted_msg_1)
         self.assertEqual(response_without_token.data['detail'], predicted_msg_2)
+
+    # ToDo: write tests for patch request
 
     def tearDown(cls):
         super(SetUpTestData, cls).tearDownClass()

--- a/mbtb_app/resources/apis/data/tissue_requests/tests.py
+++ b/mbtb_app/resources/apis/data/tissue_requests/tests.py
@@ -190,14 +190,15 @@ class GetNewTissueRequestsViewTest(SetUpTestData):
 
     # Test: invalid delete request
     def test_delete_request(self):
-        predicted_msg = 'Authentication credentials were not provided.'
+        predicted_msg_1 = 'Not found.'
+        predicted_msg_2 = 'Invalid input. Only `Token` tag is allowed.'
         response_without_token = self.admin_client.delete('/get_new_tissue_requests/1/')
         self.admin_client.credentials(HTTP_AUTHORIZATION='Token ' + self.admin_token.decode('utf-8'))
         response_with_token = self.admin_client.delete('/get_new_tissue_requests/1/')
-        self.assertEqual(response_with_token.status_code, status.HTTP_403_FORBIDDEN)
+        self.assertEqual(response_with_token.status_code, status.HTTP_404_NOT_FOUND)
         self.assertEqual(response_without_token.status_code, status.HTTP_403_FORBIDDEN)
-        self.assertEqual(response_with_token.data['detail'], predicted_msg)
-        self.assertEqual(response_without_token.data['detail'], predicted_msg)
+        self.assertEqual(response_with_token.data['detail'], predicted_msg_1)
+        self.assertEqual(response_without_token.data['detail'], predicted_msg_2)
 
     def tearDown(cls):
         super(SetUpTestData, cls).tearDownClass()
@@ -273,14 +274,15 @@ class GetArchiveTissueRequestsViewTest(SetUpTestData):
 
     # Test: delete request
     def test_delete_request(self):
-        predicted_msg = 'Authentication credentials were not provided.'
+        predicted_msg_1 = 'Not found.'
+        predicted_msg_2 = 'Invalid input. Only `Token` tag is allowed.'
         response_without_token = self.admin_client.delete('/get_archive_tissue_requests/1/')
         self.admin_client.credentials(HTTP_AUTHORIZATION='Token ' + self.admin_token.decode('utf-8'))
         response_with_token = self.admin_client.delete('/get_archive_tissue_requests/1/')
-        self.assertEqual(response_with_token.status_code, status.HTTP_403_FORBIDDEN)
+        self.assertEqual(response_with_token.status_code, status.HTTP_404_NOT_FOUND)
         self.assertEqual(response_without_token.status_code, status.HTTP_403_FORBIDDEN)
-        self.assertEqual(response_with_token.data['detail'], predicted_msg)
-        self.assertEqual(response_without_token.data['detail'], predicted_msg)
+        self.assertEqual(response_with_token.data['detail'], predicted_msg_1)
+        self.assertEqual(response_without_token.data['detail'], predicted_msg_2)
 
     def tearDown(cls):
         super(SetUpTestData, cls).tearDownClass()

--- a/mbtb_app/resources/apis/data/tissue_requests/tests.py
+++ b/mbtb_app/resources/apis/data/tissue_requests/tests.py
@@ -1,0 +1,133 @@
+from rest_framework import status
+from rest_framework.test import APITestCase, force_authenticate, APIClient
+from .models import TissueRequests
+from mbtb.models import AdminAccount, UserAccount
+from .serializers import TissueRequestsSerializer
+import jwt
+
+
+# This class is to set up test data
+class SetUpTestData(APITestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        cls.test_data = {
+            "first_name": "test",
+            "last_name": "test",
+            "email": "test@gmail.com",
+            "institution": "dal",
+            "department_name": "med",
+            "city": "test",
+            "province": "ns",
+            "postal_code": "test",
+            "project_title": "mbtb_app",
+            "source_of_funding": "dal",
+            "abstract": "test"
+        }
+        cls.model_response = TissueRequests.objects.create(**cls.test_data)
+        # Admin Authentication: generate temp account and token
+        cls.email = 'admin@mbtb.ca'
+        cls.password = 'asdfghjkl123'
+        AdminAccount.objects.create(email=cls.email, password_hash=cls.password)
+        admin = AdminAccount.objects.get(email=cls.email)
+        payload = {
+            'id': admin.id,
+            'email': admin.email,
+        }
+        cls.token = jwt.encode(payload, "SECRET_KEY", algorithm='HS256')  # generating jwt token
+        cls.client = APIClient(enforce_csrf_checks=True)  # enforcing csrf checks
+
+    @classmethod
+    def tearDownClass(cls):
+        pass
+
+
+class PostNewTissueRequestsViewTest(SetUpTestData):
+
+    def setUp(cls):
+        super(SetUpTestData, cls).setUpClass()
+
+    def tearDown(cls):
+        super(SetUpTestData, cls).tearDownClass()
+
+
+class GetNewTissueRequestsViewTest(SetUpTestData):
+
+    def setUp(cls):
+        super(SetUpTestData, cls).setUpClass()
+
+    def test_get_all_new_tissue_request(self):
+        self.client.credentials(HTTP_AUTHORIZATION='Token ' + self.token.decode('utf-8'))
+        response = self.client.get('/get_new_tissue_requests/')
+        model_response = TissueRequests.objects.all()
+        serializer_response = TissueRequestsSerializer(model_response, many=True)
+        self.assertEqual(response.data, serializer_response.data)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.client.credentials()
+
+    def test_invalid_request(self):
+        predicted_msg = 'Invalid input. Only `Token` tag is allowed.'
+        response = self.client.get('/get_new_tissue_requests/')
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+        self.assertEqual(response.data['detail'], predicted_msg)
+
+    def test_get_single_tissue_request(self):
+        url = '/get_new_tissue_requests/' + str(self.model_response.pk) + '/'
+        self.client.credentials(HTTP_AUTHORIZATION='Token ' + self.token.decode('utf-8'))
+        response = self.client.get(url)
+        model_response = TissueRequests.objects.get(pk=self.model_response.pk)
+        serializer_response = TissueRequestsSerializer(model_response)
+        self.assertEqual(response.data, serializer_response.data)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.client.credentials()
+
+    def test_get_invalid_single_request(self):
+        url = '/get_new_tissue_requests/' + '25' + '/'
+        self.client.credentials(HTTP_AUTHORIZATION='Token ' + self.token.decode('utf-8'))
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+        self.client.credentials()
+
+    def test_get_request_with_empty_token(self):
+        self.client.credentials(HTTP_AUTHORIZATION='Token ' + '')
+        response_with_token = self.client.get('/get_new_tissue_requests/')
+        self.assertEqual(response_with_token.status_code, status.HTTP_403_FORBIDDEN)
+
+    def test_get_request_with_invalid_token_header(self):
+        predicted_msg = 'Invalid token header'
+        self.client.credentials(HTTP_AUTHORIZATION='Token ' + ' get request with valid token')
+        response_invalid_header = self.client.get('/get_new_tissue_requests/')
+        self.assertEqual(response_invalid_header.status_code, status.HTTP_403_FORBIDDEN)
+        self.assertEqual(response_invalid_header.data['detail'], predicted_msg)
+
+    def test_post_request(self):
+        predicted_msg = 'Authentication credentials were not provided.'
+        response_without_token = self.client.post('/get_new_tissue_requests/1/')
+        self.client.credentials(HTTP_AUTHORIZATION='Token ' + self.token.decode('utf-8'))
+        response_with_token = self.client.post('/get_new_tissue_requests/1/')
+        self.assertEqual(response_with_token.status_code, status.HTTP_403_FORBIDDEN)
+        self.assertEqual(response_without_token.status_code, status.HTTP_403_FORBIDDEN)
+        self.assertEqual(response_with_token.data['detail'], predicted_msg)
+        self.assertEqual(response_without_token.data['detail'], predicted_msg)
+
+    def test_delete_request(self):
+        predicted_msg = 'Authentication credentials were not provided.'
+        response_without_token = self.client.delete('/get_new_tissue_requests/1/')
+        self.client.credentials(HTTP_AUTHORIZATION='Token ' + self.token.decode('utf-8'))
+        response_with_token = self.client.delete('/get_new_tissue_requests/1/')
+        self.assertEqual(response_with_token.status_code, status.HTTP_403_FORBIDDEN)
+        self.assertEqual(response_without_token.status_code, status.HTTP_403_FORBIDDEN)
+        self.assertEqual(response_with_token.data['detail'], predicted_msg)
+        self.assertEqual(response_without_token.data['detail'], predicted_msg)
+
+    def tearDown(cls):
+        super(SetUpTestData, cls).tearDownClass()
+
+
+class GetArchiveTissueRequestsViewTest(SetUpTestData):
+
+    def setUp(cls):
+        super(SetUpTestData, cls).setUpClass()
+
+    def tearDown(cls):
+        super(SetUpTestData, cls).tearDownClass()

--- a/mbtb_app/resources/apis/data/tissue_requests/urls.py
+++ b/mbtb_app/resources/apis/data/tissue_requests/urls.py
@@ -1,0 +1,12 @@
+from django.urls import path, include
+from . import views
+from rest_framework import routers
+
+router = routers.DefaultRouter()
+router.register('add_new_tissue_requests', views.PostNewTissueRequestsAPIView)
+router.register('get_new_tissue_requests', views.GetNewTissueRequestsAPIView)
+router.register('get_archive_tissue_requests', views.GetArchiveTissueRequestsAPIView)
+
+urlpatterns = [
+    path('', include(router.urls)),
+]

--- a/mbtb_app/resources/apis/data/tissue_requests/urls.py
+++ b/mbtb_app/resources/apis/data/tissue_requests/urls.py
@@ -3,9 +3,9 @@ from . import views
 from rest_framework import routers
 
 router = routers.DefaultRouter()
-router.register('add_new_tissue_requests', views.PostNewTissueRequestsAPIView)
-router.register('get_new_tissue_requests', views.GetNewTissueRequestsAPIView)
-router.register('get_archive_tissue_requests', views.GetArchiveTissueRequestsAPIView)
+router.register('add_new_tissue_requests', views.PostNewTissueRequestsView)
+router.register('get_new_tissue_requests', views.GetNewTissueRequestsView)
+router.register('get_archive_tissue_requests', views.GetArchiveTissueRequestsView)
 
 urlpatterns = [
     path('', include(router.urls)),

--- a/mbtb_app/resources/apis/data/tissue_requests/views.py
+++ b/mbtb_app/resources/apis/data/tissue_requests/views.py
@@ -1,0 +1,26 @@
+from rest_framework import viewsets
+from .models import TissueRequests
+from .serializers import TissueRequestsSerializer
+from mbtb.permissions.is_authenticated import IsAuthenticated
+from mbtb.permissions.is_admin import IsAdmin
+
+
+# This class is to add a new tissue request, permission user only
+class PostNewTissueRequestsAPIView(viewsets.ModelViewSet):
+    permission_classes = [IsAuthenticated]
+    queryset = TissueRequests.objects.all()
+    serializer_class = TissueRequestsSerializer
+
+
+# This class is to fetch new tissue requests and confirm those requests, permission admin only
+class GetNewTissueRequestsAPIView(viewsets.ModelViewSet):
+    permission_classes = [IsAdmin]
+    queryset = TissueRequests.objects.filter(pending_approval='Y')  # filtering to fetch only pending requests
+    serializer_class = TissueRequestsSerializer
+
+
+# This class is to fetch archive tissue requests, permission admin only
+class GetArchiveTissueRequestsAPIView(viewsets.ModelViewSet):
+    permission_classes = [IsAdmin]
+    queryset = TissueRequests.objects.filter(pending_approval='N')  # filtering to fetch only archive requests
+    serializer_class = TissueRequestsSerializer

--- a/mbtb_app/resources/apis/data/tissue_requests/views.py
+++ b/mbtb_app/resources/apis/data/tissue_requests/views.py
@@ -6,21 +6,21 @@ from mbtb.permissions.is_admin import IsAdmin
 
 
 # This class is to add a new tissue request, permission user only
-class PostNewTissueRequestsAPIView(viewsets.ModelViewSet):
+class PostNewTissueRequestsView(viewsets.ModelViewSet):
     permission_classes = [IsAuthenticated]
     queryset = TissueRequests.objects.all()
     serializer_class = TissueRequestsSerializer
 
 
 # This class is to fetch new tissue requests and confirm those requests, permission admin only
-class GetNewTissueRequestsAPIView(viewsets.ModelViewSet):
+class GetNewTissueRequestsView(viewsets.ModelViewSet):
     permission_classes = [IsAdmin]
     queryset = TissueRequests.objects.filter(pending_approval='Y')  # filtering to fetch only pending requests
     serializer_class = TissueRequestsSerializer
 
 
 # This class is to fetch archive tissue requests, permission admin only
-class GetArchiveTissueRequestsAPIView(viewsets.ModelViewSet):
+class GetArchiveTissueRequestsView(viewsets.ModelViewSet):
     permission_classes = [IsAdmin]
     queryset = TissueRequests.objects.filter(pending_approval='N')  # filtering to fetch only archive requests
     serializer_class = TissueRequestsSerializer

--- a/mbtb_app/web_portal/mbtb_portal/api/controllers/admin/approve-tissue-requests.js
+++ b/mbtb_app/web_portal/mbtb_portal/api/controllers/admin/approve-tissue-requests.js
@@ -1,0 +1,66 @@
+const request = require('request');
+
+module.exports = {
+
+
+  friendlyName: 'Approve new tissue requests',
+
+
+  description: `It approves new tissue requests from admin side`,
+
+
+  inputs: {
+    requests_ids:{
+      type: 'json',
+      required: true,
+      description: 'Receives selected ids from users for patch request'
+    },
+
+  },
+
+
+  exits: {
+
+  },
+
+
+  fn: async function (inputs, exits) {
+    let requests_ids = inputs.requests_ids;
+
+    // looping through received ids for tissue requests
+    for (i=0; i<requests_ids.length; i++){
+
+      // url for API
+      let url = sails.config.custom.data_api_url + 'get_new_tissue_requests/' + requests_ids[i] + '/';
+      let payload = {
+        pending_approval: "N",
+      };
+
+      // patch request for updating following fields: `pending_approval`
+      // along with admin auth token
+      request.patch({url: url, body: payload, json: true,
+          'headers': {
+            'content-type': 'application/json',
+            'Authorization': 'Token ' + this.req.session.admin_auth_token_val,
+          }
+        },
+        function optionalCallback(err, httpResponse, body) {
+          if (err) {
+            console.log({
+              'error_controller': 'admin/get-archive-tissue-requests',
+              'error_msg': err
+            }); // log error to server console
+            return exits.error_response({'msg_title': 'Error', 'msg_body': sails.config.custom.api_down_error_msg});
+          }
+          else {
+            // log approved request IDs
+            console.log("New tissue request approved, ID: ", requests_ids[i-1]);
+          }
+        });
+
+    }
+    return exits.success("approved");
+  }
+
+
+};

--- a/mbtb_app/web_portal/mbtb_portal/api/controllers/admin/approve-tissue-requests.js
+++ b/mbtb_app/web_portal/mbtb_portal/api/controllers/admin/approve-tissue-requests.js
@@ -1,4 +1,5 @@
 const request = require('request');
+const moment = require('moment');
 
 module.exports = {
 
@@ -34,6 +35,7 @@ module.exports = {
       let url = sails.config.custom.data_api_url + 'get_new_tissue_requests/' + requests_ids[i] + '/';
       let payload = {
         pending_approval: "N",
+        approval_date: moment().format('YYYY-MM-DD'),
       };
 
       // patch request for updating following fields: `pending_approval`

--- a/mbtb_app/web_portal/mbtb_portal/api/controllers/admin/delete-archive-tissue-requests.js
+++ b/mbtb_app/web_portal/mbtb_portal/api/controllers/admin/delete-archive-tissue-requests.js
@@ -1,0 +1,62 @@
+const request = require('request');
+
+module.exports = {
+
+
+  friendlyName: 'Delete archived tissue requests',
+
+
+  description: 'This controller is to delete archived tissue requests.',
+
+
+  inputs: {
+    requests_ids:{
+      type: 'json',
+      required: true,
+      description: 'Receives selected ids from users for delete request'
+    },
+
+  },
+
+
+  exits: {
+
+  },
+
+
+  fn: async function (inputs, exits) {
+    let request_ids = inputs.requests_ids;
+
+    for (i=0; i<request_ids.length; i++){
+
+      // url for API
+      let url = sails.config.custom.data_api_url + 'get_archive_tissue_requests/' + request_ids[i] + '/';
+
+      // delete request to remove archived tissue requests
+      // along with admin auth token
+      request.delete(
+        {url: url,
+          'headers': {
+            'Authorization': 'Token ' + this.req.session.admin_auth_token_val,
+          }
+        },
+        function optionalCallback(err, httpResponse, body) {
+          if (err) {
+            console.log({
+              'error_controller': 'admin/delete-archive-tissue-requests',
+              'error_msg': err
+            }); // log error to server console
+            return exits.error_response({'msg_title': 'Error', 'msg_body': sails.config.custom.api_down_error_msg});
+          }
+          else {
+            // log approved request IDs
+            console.log("Tissue request deleted, ID: ", request_ids[i-1]);
+          }
+        });
+    }
+    return exits.success("completed");
+
+  }
+
+
+};

--- a/mbtb_app/web_portal/mbtb_portal/api/controllers/admin/delete-tissue-requests.js
+++ b/mbtb_app/web_portal/mbtb_portal/api/controllers/admin/delete-tissue-requests.js
@@ -1,0 +1,65 @@
+const request = require('request');
+
+module.exports = {
+
+
+  friendlyName: 'Delete tissue requests',
+
+
+  description: 'This controller is to delete tissue requests.',
+
+
+  inputs: {
+    requests_ids:{
+      type: 'json',
+      required: true,
+      description: 'Receives selected ids from users for delete request'
+    },
+
+  },
+
+
+  exits: {
+    error_response: {
+      responseType: 'view',
+      viewTemplatePath: 'pages/message',
+      description: 'return view if APIs are down.'
+    }
+  },
+
+
+  fn: async function (inputs, exits) {
+    let request_ids = inputs.requests_ids;
+
+    for (i=0; i<request_ids.length; i++){
+
+      // url for API
+      let url = sails.config.custom.data_api_url + 'get_new_tissue_requests/' + request_ids[i] + '/';
+
+      // delete request to remove new tissue requests
+      // along with admin auth token
+      request.delete({url: url,
+          'headers': {
+            'Authorization': 'Token ' + this.req.session.admin_auth_token_val,
+          }
+        },
+        function optionalCallback(err, httpResponse, body) {
+          if (err) {
+            console.log({
+              'error_controller': 'admin/delete-tissue-requests',
+              'error_msg': err
+            }); // log error to server console
+            return exits.error_response({'msg_title': 'Error', 'msg_body': sails.config.custom.api_down_error_msg});
+          }
+          else {
+            // log approved request IDs
+            console.log("Tissue request deleted, ID: ", request_ids[i-1]);
+          }
+        });
+    }
+    return exits.success("completed");
+
+  }
+
+
+};

--- a/mbtb_app/web_portal/mbtb_portal/api/controllers/admin/file-upload-add-data.js
+++ b/mbtb_app/web_portal/mbtb_portal/api/controllers/admin/file-upload-add-data.js
@@ -6,7 +6,7 @@ module.exports = {
   friendlyName: 'Admin - File upload',
 
 
-  description: 'This controller upload file to sails js and send it via post request to API',
+  description: 'This controller upload file to sails js and send it via POST request to API for add new data',
 
 
   inputs: {

--- a/mbtb_app/web_portal/mbtb_portal/api/controllers/admin/file-upload-edit-data.js
+++ b/mbtb_app/web_portal/mbtb_portal/api/controllers/admin/file-upload-edit-data.js
@@ -1,0 +1,102 @@
+const request = require('request');
+const fs = require('fs');
+
+module.exports = {
+
+  friendlyName: 'Admin - File upload',
+
+
+  description: 'This controller upload file to sails js and send it via PATCH request to API for edit data',
+
+
+  inputs: {
+
+  },
+
+
+  exits: {
+    return_view: {
+      responseType: 'view',
+      viewTemplatePath: 'pages/admin_message_response',
+      description: 'return view to display msg'
+    }
+  },
+
+
+  fn: async function (inputs, exits) {
+
+    let req = this.req;
+    let res = this.res;
+
+    let url = sails.config.custom.data_api_url + 'file_upload/';
+    let upload_file = req.file('upload_file'); // getting file from request
+    let temp_file_dir = '';
+
+    // Uploading file to sails first
+    upload_file.upload({
+        maxBytes : 500000000}, // file upload size limit 500 MB
+      function onUploadComplete(err, files) {
+
+        // Files will be uploaded to .tmp/uploads
+        if (err) {
+          return res.serverError(err);  // IF ERROR Return and send 500 error with error
+        }
+        temp_file_dir = files[0].fd; // temporary file path
+
+        request.patch({
+            url: url,
+            formData: {
+              'file': fs.createReadStream(temp_file_dir)
+            },
+            'headers': {
+              'Authorization': 'Token ' + req.session.admin_auth_token_val,
+              'Content-Type': 'multipart/form-data'
+            }
+          },
+          function optionalCallback(err, httpResponse, body) {
+            fs.unlink(temp_file_dir, function(file_error) { // removing uploaded file to sails
+              if (file_error) return console.log(err); // log error related to deleting file
+
+              if (err) {
+                console.log(err); // log error to server console related to post request
+              }
+              else {
+
+                try {
+                  const response = JSON.parse(body);
+
+                  if(response.Error){
+                    // for displaying validation data validation error
+                    if (response.Message === undefined){
+                      msg = JSON.stringify(response.Error);
+                      return exits.return_view({'msg_title': 'Error', 'msg_body': msg}) // display error msg
+                    }
+
+                    // for displaying column names error
+                    msg = response.Message + ' with following reason: ' + JSON.stringify(response.Error);
+                    return exits.return_view({'msg_title': 'Error', 'msg_body': msg}) // display error msg
+                  }
+
+                  // for displaying successful response
+                  else if (response.Response){
+                    let view_data_url = 'admin_view_data/' ;
+                    msg = 'Cheers, Your data is updated.';
+                    return exits.return_view({'msg_title': 'Confirmation', 'msg_body': msg, view_data_url: view_data_url});
+                  }
+                }
+
+                catch (e) {
+                  msg = 'Something went wrong, Please try again';
+                  return exits.return_view({'msg_title': 'Error', 'msg_body': msg});
+                }
+              }
+
+            });
+
+          });
+
+      });
+
+  }
+
+};

--- a/mbtb_app/web_portal/mbtb_portal/api/controllers/admin/get-archive-tissue-requests.js
+++ b/mbtb_app/web_portal/mbtb_portal/api/controllers/admin/get-archive-tissue-requests.js
@@ -3,10 +3,10 @@ const request = require('request');
 module.exports = {
 
 
-  friendlyName: 'Admin - Get new tissue requests',
+  friendlyName: 'Admin - Get archive tissue requests',
 
 
-  description: 'This controller is to fetch new tissue requests and display it.',
+  description: 'This controller is to fetch archived tissue requests and display it.',
 
 
   inputs: {
@@ -16,8 +16,8 @@ module.exports = {
 
   exits: {
     success: {
-      viewTemplatePath: 'pages/admin_new_tissue_requests',
-      description: 'On success, redirect admin to `admin_new_tissue_requests` template',
+      viewTemplatePath: 'pages/admin_archive_tissue_requests',
+      description: 'On success, redirect admin to `admin_arhive_tissue_requests` template',
       locals: {
         layout: 'layouts/admin_layout'
       }
@@ -33,7 +33,7 @@ module.exports = {
 
 
   fn: async function (inputs, exits) {
-    let url = sails.config.custom.data_api_url + 'get_new_tissue_requests/';
+    let url = sails.config.custom.data_api_url + 'get_archive_tissue_requests/';
 
     // get request to retrieve registration requests from api with admin auth token
     request.get(url, {
@@ -43,7 +43,7 @@ module.exports = {
       function optionalCallback(err, httpResponse, body) {
         if (err) {
           console.log({
-            'error_controller': 'admin/get-tissue-requests',
+            'error_controller': 'admin/get-archive-tissue-requests',
             'error_msg': err
           }); // log error to server console
           return exits.error_response({'msg_title': 'Error', 'msg_body': sails.config.custom.api_down_error_msg})

--- a/mbtb_app/web_portal/mbtb_portal/api/controllers/admin/get-archive-tissue-requests.js
+++ b/mbtb_app/web_portal/mbtb_portal/api/controllers/admin/get-archive-tissue-requests.js
@@ -46,7 +46,7 @@ module.exports = {
             'error_controller': 'admin/get-archive-tissue-requests',
             'error_msg': err
           }); // log error to server console
-          return exits.error_response({'msg_title': 'Error', 'msg_body': sails.config.custom.api_down_error_msg})
+          return exits.error_response({'msg_title': 'Error', 'msg_body': sails.config.custom.api_down_error_msg});
         }
         else {
           const response = JSON.parse(body);

--- a/mbtb_app/web_portal/mbtb_portal/api/controllers/admin/get-file-upload-add-data-view.js
+++ b/mbtb_app/web_portal/mbtb_portal/api/controllers/admin/get-file-upload-add-data-view.js
@@ -24,8 +24,9 @@ module.exports = {
 
 
   fn: async function (inputs, exits) {
-
-    return exits.success();
+    let data_mode = 'Add New Data';
+    let url = 'file_upload/';
+    return exits.success({data_mode: data_mode, url: url});
 
   }
 

--- a/mbtb_app/web_portal/mbtb_portal/api/controllers/admin/get-file-upload-edit-data-view.js
+++ b/mbtb_app/web_portal/mbtb_portal/api/controllers/admin/get-file-upload-edit-data-view.js
@@ -1,0 +1,34 @@
+module.exports = {
+
+
+  friendlyName: 'Admin - Get file upload view',
+
+
+  description: 'This controller is to displaying admin_file_upload ejs template for edit data via file',
+
+
+  inputs: {
+
+  },
+
+
+  exits: {
+    success:{
+      viewTemplatePath: 'pages/admin_file_upload',
+      description: 'return view for displaying under construction msg',
+      locals: {
+        layout: 'layouts/admin_layout'
+      }
+    }
+  },
+
+
+  fn: async function (inputs, exits) {
+    let data_mode = 'Edit Data';
+    let url = 'edit_file_upload/';
+    return exits.success({data_mode: data_mode, url: url});
+
+  }
+
+
+};

--- a/mbtb_app/web_portal/mbtb_portal/api/controllers/admin/get-tissue-requests.js
+++ b/mbtb_app/web_portal/mbtb_portal/api/controllers/admin/get-tissue-requests.js
@@ -1,0 +1,61 @@
+const request = require('request');
+
+module.exports = {
+
+
+  friendlyName: 'Admin - Get tissue requests',
+
+
+  description: 'This controller is to fetch new tissue reqeust and dispaly it.',
+
+
+  inputs: {
+
+  },
+
+
+  exits: {
+    success: {
+      viewTemplatePath: 'pages/admin_new_tissue_requests',
+      description: 'On success, redirect admin to `admin_register_requests` template',
+      locals: {
+        layout: 'layouts/admin_layout'
+      }
+    },
+
+    error_response: {
+      responseType: 'view',
+      viewTemplatePath: 'pages/message',
+      description: 'return view if APIs are down.'
+    }
+
+  },
+
+
+  fn: async function (inputs, exits) {
+    let url = sails.config.custom.data_api_url + 'get_new_tissue_requests/';
+
+    // get request to retrieve registration requests from api with admin auth token
+    request.get(url, {
+        'headers': {
+          'Authorization': 'Token ' + this.req.session.admin_auth_token_val,
+        }},
+      function optionalCallback(err, httpResponse, body) {
+        if (err) {
+          console.log({
+            'error_controller': 'admin/get-tissue-requests',
+            'error_msg': err
+          }); // log error to server console
+          return exits.error_response({'msg_title': 'Error', 'msg_body': sails.config.custom.api_down_error_msg})
+        }
+        else {
+          const response = JSON.parse(body);
+          // return retrieved data to template in form of dictionary with key: `data`
+          return exits.success({data: response});
+        }
+      });
+
+  }
+
+
+};

--- a/mbtb_app/web_portal/mbtb_portal/api/controllers/admin/login.js
+++ b/mbtb_app/web_portal/mbtb_portal/api/controllers/admin/login.js
@@ -53,7 +53,7 @@ module.exports = {
             'error_controller': 'admin/login',
             'error_msg': err
           }); // log error to server console
-          return exits.error_response({'msg_title': 'Error', 'msg_body': sails.config.custom.api_down_error_msg})
+          return exits.error_response({'msg_title': 'Error', 'msg_body': sails.config.custom.api_down_error_msg});
         }
         else {
           try {

--- a/mbtb_app/web_portal/mbtb_portal/api/controllers/admin/login.js
+++ b/mbtb_app/web_portal/mbtb_portal/api/controllers/admin/login.js
@@ -24,6 +24,12 @@ module.exports = {
       responseType: 'view',
       viewTemplatePath: 'pages/admin_login',
       description: 'return view for password mismatch, display error msg'
+    },
+
+    error_response: {
+      responseType: 'view',
+      viewTemplatePath: 'pages/message',
+      description: 'return view if APIs are down.'
     }
   },
 
@@ -42,8 +48,9 @@ module.exports = {
     // post request for retrieving auth token from api, with credentials as payload
     request.post({url: url, formData: credentials},
       function optionalCallback(err, httpResponse, body) {
-        if (err && httpResponse.statusCode !== 200) {
-          return exits.bad_combo({'error_msg': err}) // display error msg if something goes wrong with request
+        if (err) {
+          let msg_body = 'Servers are down, please contact site admin for the help.';
+          return exits.error_response({'msg_title': 'Error', 'msg_body': msg_body})
         }
         else {
           try {

--- a/mbtb_app/web_portal/mbtb_portal/api/controllers/admin/login.js
+++ b/mbtb_app/web_portal/mbtb_portal/api/controllers/admin/login.js
@@ -49,8 +49,11 @@ module.exports = {
     request.post({url: url, formData: credentials},
       function optionalCallback(err, httpResponse, body) {
         if (err) {
-          let msg_body = 'Servers are down, please contact site admin for the help.';
-          return exits.error_response({'msg_title': 'Error', 'msg_body': msg_body})
+          console.log({
+            'error_controller': 'admin/login',
+            'error_msg': err
+          }); // log error to server console
+          return exits.error_response({'msg_title': 'Error', 'msg_body': sails.config.custom.api_down_error_msg})
         }
         else {
           try {

--- a/mbtb_app/web_portal/mbtb_portal/api/controllers/admin/revert-archive-tissue-requests.js
+++ b/mbtb_app/web_portal/mbtb_portal/api/controllers/admin/revert-archive-tissue-requests.js
@@ -1,4 +1,5 @@
 const request = require('request');
+const moment = require('moment');
 
 module.exports = {
 
@@ -34,6 +35,7 @@ module.exports = {
       let url = sails.config.custom.data_api_url + 'get_archive_tissue_requests/' + requests_ids[i] + '/';
       let payload = {
         pending_approval: "Y",
+        reverted_date: moment().format('YYYY-MM-DD')
       };
 
       // patch request for updating following fields: `pending_approval`

--- a/mbtb_app/web_portal/mbtb_portal/api/controllers/admin/revert-archive-tissue-requests.js
+++ b/mbtb_app/web_portal/mbtb_portal/api/controllers/admin/revert-archive-tissue-requests.js
@@ -3,10 +3,10 @@ const request = require('request');
 module.exports = {
 
 
-  friendlyName: 'Approve new tissue requests',
+  friendlyName: 'Revert archive tissue requests to new requests',
 
 
-  description: `It approves new tissue requests from admin side`,
+  description: `It reverts state of archive tissue requests to new tissue requests.`,
 
 
   inputs: {
@@ -31,9 +31,9 @@ module.exports = {
     for (i=0; i<requests_ids.length; i++){
 
       // url for API
-      let url = sails.config.custom.data_api_url + 'get_new_tissue_requests/' + requests_ids[i] + '/';
+      let url = sails.config.custom.data_api_url + 'get_archive_tissue_requests/' + requests_ids[i] + '/';
       let payload = {
-        pending_approval: "N",
+        pending_approval: "Y",
       };
 
       // patch request for updating following fields: `pending_approval`
@@ -47,14 +47,14 @@ module.exports = {
         function optionalCallback(err, httpResponse, body) {
           if (err) {
             console.log({
-              'error_controller': 'admin/approve-tissue-requests',
+              'error_controller': 'admin/revert-archive-tissue-requests',
               'error_msg': err
             }); // log error to server console
             return exits.error_response({'msg_title': 'Error', 'msg_body': sails.config.custom.api_down_error_msg});
           }
           else {
             // log approved request IDs
-            console.log("New tissue request approved, ID: ", requests_ids[i-1]);
+            console.log("Archived tissue request reverted, ID: ", requests_ids[i-1]);
           }
         });
 

--- a/mbtb_app/web_portal/mbtb_portal/api/controllers/admin/view-data-guide.js
+++ b/mbtb_app/web_portal/mbtb_portal/api/controllers/admin/view-data-guide.js
@@ -1,7 +1,7 @@
 module.exports = {
 
 
-  friendlyName: 'Data uploading guide',
+  friendlyName: 'Admin - View Data Guide',
 
 
   description: '',
@@ -14,8 +14,8 @@ module.exports = {
 
   exits: {
     success:{
-      viewTemplatePath: 'pages/admin_data_uploading_guide',
-      description: 'return view for displaying data uploading guide',
+      viewTemplatePath: 'pages/view_data_guide',
+      description: 'return view for displaying view data guide',
       locals: {
         layout: 'layouts/admin_layout'
       }

--- a/mbtb_app/web_portal/mbtb_portal/api/controllers/admin/view-single-archive-tissue-request.js
+++ b/mbtb_app/web_portal/mbtb_portal/api/controllers/admin/view-single-archive-tissue-request.js
@@ -3,10 +3,10 @@ const request = require('request');
 module.exports = {
 
 
-  friendlyName: 'View single tissue request',
+  friendlyName: 'View single archived tissue request',
 
 
-  description: 'Retrieve single tissue request from api',
+  description: 'Retrieve single archived tissue request from api',
 
 
   inputs: {
@@ -23,8 +23,8 @@ module.exports = {
   exits: {
 
     success: {
-      viewTemplatePath: 'pages/admin_view_single_tissue_request',
-      description: 'On success, return to `admin_view_single_tissue_request` template',
+      viewTemplatePath: 'pages/admin_view_single_archive_tissue_request',
+      description: 'On success, return to `admin_view_single_archive_tissue_request` template',
       locals: {
         layout: 'layouts/admin_layout'
       }
@@ -42,7 +42,7 @@ module.exports = {
   fn: async function ({id}, exits) {
 
     // get request to retrieve detailed mbtb data for single id from api with admin auth token
-    let url = sails.config.custom.data_api_url + 'get_new_tissue_requests/' + id + '/';
+    let url = sails.config.custom.data_api_url + 'get_archive_tissue_requests/' + id + '/';
     request.get(url, {
         'headers': {
           'Authorization': 'Token ' + this.req.session.admin_auth_token_val,
@@ -50,7 +50,7 @@ module.exports = {
       function optionalCallback(err, httpResponse, body) {
         if (err) {
           console.log({
-            'error_controller': 'admin/view-single-tissue-request',
+            'error_controller': 'admin/view-single-archive-tissue-request',
             'error_msg': err
           }); // log error to server console
           return exits.error_response({'msg_title': 'Error', 'msg_body': sails.config.custom.api_down_error_msg});

--- a/mbtb_app/web_portal/mbtb_portal/api/controllers/admin/view-single-tissue-request.js
+++ b/mbtb_app/web_portal/mbtb_portal/api/controllers/admin/view-single-tissue-request.js
@@ -1,0 +1,70 @@
+const request = require('request');
+
+module.exports = {
+
+
+  friendlyName: 'View single tissue request',
+
+
+  description: 'Retrieve single tissue request from api',
+
+
+  inputs: {
+
+    id: {
+      description: 'The id of the tissue_request for detail view',
+      type: 'number',
+      required: true
+    },
+
+  },
+
+
+  exits: {
+
+    success: {
+      viewTemplatePath: 'pages/admin_view_single_tissue_request',
+      description: 'On sucess, return to `admin_view_single_tissue_request` template',
+      locals: {
+        layout: 'layouts/admin_layout'
+      }
+    },
+
+    error_response: {
+      responseType: 'view',
+      viewTemplatePath: 'pages/message',
+      description: 'return view if APIs are down.'
+    }
+
+  },
+
+
+  fn: async function ({id}, exits) {
+
+    // get request to retrieve detailed mbtb data for single id from api with admin auth token
+    let url = sails.config.custom.data_api_url + 'get_new_tissue_requests/' + id + '/';
+    request.get(url, {
+        'headers': {
+          'Authorization': 'Token ' + this.req.session.admin_auth_token_val,
+        }},
+      function optionalCallback(err, httpResponse, body) {
+        if (err) {
+          console.log({
+            'error_controller': 'admin/view-single-tissue-request',
+            'error_msg': err
+          }); // log error to server console
+          return exits.error_response({'msg_title': 'Error', 'msg_body': sails.config.custom.api_down_error_msg});
+        }
+        else {
+          var response = JSON.parse(body);
+
+          // return retrieved data to template in form of dictionary with key: `detailed_data`
+          return exits.success({detailed_data: response});
+        }
+      });
+
+
+  }
+
+
+};

--- a/mbtb_app/web_portal/mbtb_portal/api/controllers/common/download-mbtb-data.js
+++ b/mbtb_app/web_portal/mbtb_portal/api/controllers/common/download-mbtb-data.js
@@ -1,0 +1,101 @@
+const request = require('request');
+
+module.exports = {
+
+
+  friendlyName: 'Download mbtb data',
+
+
+  description: 'Returning mbtb data in json format for admin & user.',
+
+
+  inputs: {
+
+    input_mbtb_codes: {
+      type: 'json',
+      required: false,
+      description: 'Receives selected mbtb_codes from users for post request'
+    },
+
+    download_mode:{
+      type: 'string',
+      required: true,
+      description: 'indicate what to download i.e. all data or filtered ones.'
+    }
+  },
+
+
+  exits: {
+
+  },
+
+
+  fn: async function (inputs, exits) {
+
+    let req = this.req;
+    let res = this.res;
+    let url = sails.config.custom.data_api_url + 'download_data/';
+    let input_mbtb_codes = inputs.input_mbtb_codes;
+    let download_mode = inputs.download_mode;
+    let payload = [];
+    let token_value = null;
+
+
+    // Validating user or admin and fetching token value. If none, redirecting to 'logout'.
+    if (req.session.admin_user){
+      token_value = req.session.admin_auth_token_val;
+    }
+
+    else if (req.session.user_type === 'user'){
+      token_value = req.session.auth_token
+    }
+    else {
+      res.redirect('/logout');
+    }
+
+
+    // Prepare payload: whether to download all data or filtered ones
+    if (download_mode === 'all'){
+      payload = {
+        download_mode: download_mode
+      };
+    }
+    else {
+      payload = {
+        download_mode: download_mode,
+        download_data: input_mbtb_codes
+      };
+    }
+
+
+    // POST request to api for fetching the data
+    request.post({
+        url: url,
+        body: payload,
+        json: true,
+        'headers': {
+          'content-type': 'application/json',
+          'Authorization': 'Token ' + token_value,
+        }
+      },
+      function optionalCallback(err, httpResponse, body) {
+        if (err) {
+          console.log({
+            'error_controller': 'common/download-mbtb-data',
+            'error_msg': err
+          }); // log error to server console
+          return exits.error_response({'msg_title': 'Error', 'msg_body': sails.config.custom.api_down_error_msg});
+        }
+        else {
+          return exits.success({data: body, operation: "completed"});
+        }
+      }
+
+
+    );
+
+
+  },
+
+
+};

--- a/mbtb_app/web_portal/mbtb_portal/api/controllers/user/get-tissue-requests-form.js
+++ b/mbtb_app/web_portal/mbtb_portal/api/controllers/user/get-tissue-requests-form.js
@@ -1,0 +1,31 @@
+module.exports = {
+
+
+  friendlyName: 'Get tissue requests form',
+
+
+  description: 'This controller display tissue request form to the users',
+
+
+  inputs: {
+
+  },
+
+
+  exits: {
+    success:{
+      responseType: 'view',
+      viewTemplatePath: 'pages/tissue_requests_form',
+      description: 'return view for displaying tissue request form'
+    }
+  },
+
+
+  fn: async function (inputs, exits) {
+
+    return exits.success();
+
+  }
+
+
+};

--- a/mbtb_app/web_portal/mbtb_portal/api/controllers/user/tissue-requests-form.js
+++ b/mbtb_app/web_portal/mbtb_portal/api/controllers/user/tissue-requests-form.js
@@ -1,0 +1,146 @@
+const request = require('request');
+
+module.exports = {
+
+
+  friendlyName: 'Tissue requests form',
+
+
+  description: 'This controller is to post tissue request data to the data api',
+
+
+  inputs: {
+    title: {
+      type: 'string',
+      required: false
+    },
+
+    first_name: {
+      type: 'string',
+      required: true
+    },
+
+    last_name: {
+      type: 'string',
+      required: true
+    },
+
+    email: {
+      type: 'string',
+      required: true
+    },
+
+    institution: {
+      type: 'string',
+      required: true
+    },
+
+    department_name: {
+      type: 'string',
+      required: true
+    },
+
+    city: {
+      type: 'string',
+      required: true
+    },
+
+    province: {
+      type: 'string',
+      required: true
+    },
+
+    postal_code: {
+      type: 'string',
+      required: true
+    },
+
+    phone_number: {
+      type: 'string',
+      required: false
+    },
+
+    fax_number: {
+      type: 'string',
+      required: false
+    },
+
+    project_title: {
+      type: 'string',
+      required: true
+    },
+
+    source_of_funding: {
+      type: 'string',
+      required: true
+    },
+
+    abstract: {
+      type: 'string',
+      required: true
+    },
+
+  },
+
+
+  exits: {
+    success:{
+      responseType: 'view',
+      viewTemplatePath: 'pages/message',
+      description: 'return view for displaying tissue request form'
+    }
+  },
+
+
+  fn: async function (inputs, exits) {
+
+    let data = {
+      title: inputs.title,
+      first_name: inputs.first_name,
+      last_name: inputs.last_name,
+      email: inputs.email,
+      institution: inputs.institution,
+      department_name: inputs.department_name,
+      city: inputs.city,
+      province: inputs.province,
+      postal_code: inputs.postal_code,
+      phone_number: inputs.phone_number,
+      fax_number: inputs.fax_number,
+      project_title: inputs.project_title,
+      source_of_funding: inputs.source_of_funding,
+      abstract: inputs.abstract,
+    };
+    let url = sails.config.custom.data_api_url + 'add_new_tissue_requests/';
+
+    request.post({
+      url: url,
+      formData: data,
+      'headers': {
+        'Authorization': 'Token ' + this.req.session.auth_token
+      }
+      },
+      function optionalCallback(err, httpResponse, body) {
+        let message_title = "";
+        let message_body = "";
+
+        if (err) {
+          message_title = "Error";
+          message_body = 'Servers are down, please contact site admin for the help.';
+          return exits.success({'msg_title': message_title, 'msg_body': message_body});
+        }
+        else if (httpResponse.statusCode === 400){
+          message_title = "Error";
+          message_body = "Invalid inputs, Please try again!";
+          return exits.success({'msg_title': message_title, 'msg_body': message_body});
+        }
+        else {
+          message_title = "Confirmation";
+          message_body = "Your data is received, Please email following documents: CV, ethics, tissue request template in order to process your request";
+          return exits.success({'msg_title': message_title, 'msg_body': message_body});
+        }
+      });
+
+  }
+
+
+};

--- a/mbtb_app/web_portal/mbtb_portal/api/controllers/user/tissue-requests-form.js
+++ b/mbtb_app/web_portal/mbtb_portal/api/controllers/user/tissue-requests-form.js
@@ -137,10 +137,9 @@ module.exports = {
         }
         else {
           const response = JSON.parse(body);
-          let tissue_request_number = moment().format('YYYYMMDD-') + String(response.tissue_requests_id).padStart(4, '0');
           message_title = "Confirmation";
           message_body = "Your data is received, kindly note down following tissue request number for reference: " +
-            tissue_request_number + ". " +
+            response.tissue_request_number + ". " +
             "Also, please email following documents: CV, ethics, tissue request template in order to process your request";
           return exits.success({'msg_title': message_title, 'msg_body': message_body});
         }

--- a/mbtb_app/web_portal/mbtb_portal/api/controllers/user/tissue-requests-form.js
+++ b/mbtb_app/web_portal/mbtb_portal/api/controllers/user/tissue-requests-form.js
@@ -1,4 +1,5 @@
 const request = require('request');
+const moment = require('moment');
 
 module.exports = {
 
@@ -109,6 +110,7 @@ module.exports = {
       project_title: inputs.project_title,
       source_of_funding: inputs.source_of_funding,
       abstract: inputs.abstract,
+      received_date: moment().format('YYYY-MM-DD')
     };
     let url = sails.config.custom.data_api_url + 'add_new_tissue_requests/';
 
@@ -134,8 +136,12 @@ module.exports = {
           return exits.success({'msg_title': message_title, 'msg_body': message_body});
         }
         else {
+          const response = JSON.parse(body);
+          let tissue_request_number = moment().format('YYYYMMDD-') + String(response.tissue_requests_id).padStart(4, '0');
           message_title = "Confirmation";
-          message_body = "Your data is received, Please email following documents: CV, ethics, tissue request template in order to process your request";
+          message_body = "Your data is received, kindly note down following tissue request number for reference: " +
+            tissue_request_number + ". " +
+            "Also, please email following documents: CV, ethics, tissue request template in order to process your request";
           return exits.success({'msg_title': message_title, 'msg_body': message_body});
         }
       });

--- a/mbtb_app/web_portal/mbtb_portal/api/controllers/user/tissue-requests-terms.js
+++ b/mbtb_app/web_portal/mbtb_portal/api/controllers/user/tissue-requests-terms.js
@@ -1,10 +1,10 @@
 module.exports = {
 
 
-  friendlyName: 'User tissue requests',
+  friendlyName: 'Get tissue requests terms',
 
 
-  description: 'It redirects users to message page',
+  description: 'It redirects users to tissue requests terms page',
 
 
   inputs: {
@@ -15,7 +15,7 @@ module.exports = {
   exits: {
     success:{
       responseType: 'view',
-      viewTemplatePath: 'pages/tissue_request_terms',
+      viewTemplatePath: 'pages/tissue_requests_terms',
       description: 'return view for displaying under construction msg'
     }
   },

--- a/mbtb_app/web_portal/mbtb_portal/api/controllers/user/user-tissue-requests.js
+++ b/mbtb_app/web_portal/mbtb_portal/api/controllers/user/user-tissue-requests.js
@@ -15,17 +15,15 @@ module.exports = {
   exits: {
     success:{
       responseType: 'view',
-      viewTemplatePath: 'pages/message',
+      viewTemplatePath: 'pages/tissue_request_terms',
       description: 'return view for displaying under construction msg'
     }
   },
 
 
   fn: async function (inputs, exits) {
-    let msg_title = 'Tissue Requests';
-    let msg_body = 'This feature is coming soon!';
 
-    return exits.success({msg_title: msg_title, msg_body: msg_body});
+    return exits.success();
 
   }
 

--- a/mbtb_app/web_portal/mbtb_portal/api/controllers/user/view-data-guide.js
+++ b/mbtb_app/web_portal/mbtb_portal/api/controllers/user/view-data-guide.js
@@ -1,0 +1,33 @@
+module.exports = {
+
+
+  friendlyName: 'View Data Guide',
+
+
+  description: '',
+
+
+  inputs: {
+
+  },
+
+
+  exits: {
+    success:{
+      viewTemplatePath: 'pages/view_data_guide',
+      description: 'return view for displaying view data guide',
+      locals: {
+        layout: 'layouts/layout'
+      }
+    }
+  },
+
+
+  fn: async function (inputs, exits) {
+
+    return exits.success();
+
+  }
+
+
+};

--- a/mbtb_app/web_portal/mbtb_portal/assets/js/admin_archive_tissue_requests.js
+++ b/mbtb_app/web_portal/mbtb_portal/assets/js/admin_archive_tissue_requests.js
@@ -7,7 +7,7 @@ $('#revert_tissue_request_btn').click(function(e){
   let post_request = $.post( "/revert_archive_tissue_requests", {requests_ids: requests_ids}, function(data, status) {
     if (data === 'approved'){
       // display alert on suceess and reload window
-      alert("Your selected requested are reverted.");
+      alert("Your selected requests are reverted.");
       location.reload();
     }
     else {

--- a/mbtb_app/web_portal/mbtb_portal/assets/js/admin_archive_tissue_requests.js
+++ b/mbtb_app/web_portal/mbtb_portal/assets/js/admin_archive_tissue_requests.js
@@ -1,0 +1,24 @@
+// To get id from selected checkbox and send a patch request to revert status
+$('#revert_tissue_request_btn').click(function(e){
+  // fetching selected checkbox's id from view
+  let requests_ids = get_checkbox_values();
+
+  // patch request for sending request_ids, email_data to controller
+  let post_request = $.post( "/revert_archive_tissue_requests", {requests_ids: requests_ids}, function(data, status) {
+    if (data === 'approved'){
+      // display alert on suceess and reload window
+      alert("Your selected requested are approved.");
+      location.reload();
+    }
+    else {
+      alert("Something went wrong, Please try again.");
+    }
+
+  });
+
+  // display error msg if no checkbox is selected
+  post_request.fail(function(status) {
+    alert( "Please select at least one request.");
+  });
+
+});

--- a/mbtb_app/web_portal/mbtb_portal/assets/js/admin_archive_tissue_requests.js
+++ b/mbtb_app/web_portal/mbtb_portal/assets/js/admin_archive_tissue_requests.js
@@ -6,7 +6,7 @@ $('#revert_tissue_request_btn').click(function(e){
   // patch request for sending request_ids, email_data to controller
   let post_request = $.post( "/revert_archive_tissue_requests", {requests_ids: requests_ids}, function(data, status) {
     if (data === 'approved'){
-      // display alert on suceess and reload window
+      // display alert on success and reload window
       alert("Your selected requests are reverted.");
       location.reload();
     }
@@ -21,4 +21,30 @@ $('#revert_tissue_request_btn').click(function(e){
     alert( "Please select at least one request.");
   });
 
+});
+
+// To get id from selected checkbox and send a delete request to remove tissue requests
+$('#delete_archive_tissue_request_btn').click(function(e){
+  if (confirm("This action will delete selected archived tissue requests. Are you sure?")) {
+    // fetching selected checkbox's id from view
+    var requests_ids = get_checkbox_values();
+
+    // patch request for sending request_ids, email_data to controller
+    var delete_request = $.post( "/delete_archive_tissue_requests", {requests_ids: requests_ids}, function(data, status) {
+      if (data === 'completed'){
+        // display alert on success and reload window
+        alert("Your selected requests are deleted.");
+        location.reload();
+      }
+      else {
+        alert("Something went wrong, Please try again.");
+      }
+
+    });
+
+    // display error msg if no checkbox is selected
+    delete_request.fail(function(status) {
+      alert( "Please select at least one request.");
+    });
+  }
 });

--- a/mbtb_app/web_portal/mbtb_portal/assets/js/admin_archive_tissue_requests.js
+++ b/mbtb_app/web_portal/mbtb_portal/assets/js/admin_archive_tissue_requests.js
@@ -7,7 +7,7 @@ $('#revert_tissue_request_btn').click(function(e){
   let post_request = $.post( "/revert_archive_tissue_requests", {requests_ids: requests_ids}, function(data, status) {
     if (data === 'approved'){
       // display alert on suceess and reload window
-      alert("Your selected requested are approved.");
+      alert("Your selected requested are reverted.");
       location.reload();
     }
     else {

--- a/mbtb_app/web_portal/mbtb_portal/assets/js/admin_edit_data.js
+++ b/mbtb_app/web_portal/mbtb_portal/assets/js/admin_edit_data.js
@@ -2,7 +2,7 @@ var admin_edit_data = angular.module("admin_edit_data_app", []);
 
 admin_edit_data.controller("admin_edit_data_controller", ['$scope', '$window', function ($scope, $window) {
 
-  // binding data to angular varible from ejs view
+  // binding data to angular variable from ejs view
   $scope.details = $window.mbtb_detailed_data;
 
 }]);

--- a/mbtb_app/web_portal/mbtb_portal/assets/js/admin_register_requests.js
+++ b/mbtb_app/web_portal/mbtb_portal/assets/js/admin_register_requests.js
@@ -9,7 +9,7 @@ $('#accept_request_btn').click(function(e){
   // patch request for sending request_ids, email_data to controller
   let post_request = $.post( "/approve_user_requests", {requests_ids: requests_ids, email_data: email_data}, function(data, status) {
     if (data === 'approved'){
-      // display alert on suceess and reload window
+      // display alert on success and reload window
       alert("Your selected requests are approved.");
       location.reload();
     }
@@ -38,7 +38,7 @@ $('#deny_request_btn').click(function(e){
   // patch request for sending request_ids, email_data to controller
   var delete_request = $.post( "/deny_user_requests", {requests_ids: requests_ids, email_data: email_data}, function(data, status) {
     if (data === 'completed'){
-      // display alert on suceess and reload window
+      // display alert on success and reload window
       alert("Your selected requests are denied.");
       location.reload();
     }

--- a/mbtb_app/web_portal/mbtb_portal/assets/js/admin_register_requests.js
+++ b/mbtb_app/web_portal/mbtb_portal/assets/js/admin_register_requests.js
@@ -88,7 +88,7 @@ function get_email_data(requests_ids) {
   return email_data;
 }
 
-// For gettings mbtb_data ids from seleted checkbox
+// For getting mbtb_data ids from selected checkbox
 // return it as array
 function get_checkbox_values() {
   var requests_ids = [];

--- a/mbtb_app/web_portal/mbtb_portal/assets/js/admin_register_requests.js
+++ b/mbtb_app/web_portal/mbtb_portal/assets/js/admin_register_requests.js
@@ -1,13 +1,13 @@
 // To get id from selected checkbox and send a patch request to approve status
 $('#accept_request_btn').click(function(e){
   // fetching selected checkbox's id from view
-  var requests_ids = get_checkbox_values();
+  let requests_ids = get_checkbox_values();
 
   // fetching email data: first_name, last_name, email from selected checkbox
-  var email_data = get_email_data(requests_ids);
+  let email_data = get_email_data(requests_ids);
 
   // patch request for sending request_ids, email_data to controller
-  var post_request = $.post( "/approve_user_requests", {requests_ids: requests_ids, email_data: email_data}, function(data, status) {
+  let post_request = $.post( "/approve_user_requests", {requests_ids: requests_ids, email_data: email_data}, function(data, status) {
     if (data === 'approved'){
       // display alert on suceess and reload window
       alert("Your selected requested are approved.");
@@ -95,8 +95,8 @@ function get_checkbox_values() {
   var data_length = document.getElementById('data_length').value;
 
   for ( var j = 0; j < data_length; j++) {
-    var check=$('input:checkbox[name=checkbox'+j+']').is(':checked');
-    if(check==true)
+    var check = $('input:checkbox[name=checkbox'+j+']').is(':checked');
+    if(check===true)
       requests_ids.push($('input:checkbox[name=checkbox'+j+']').val());
   }
 

--- a/mbtb_app/web_portal/mbtb_portal/assets/js/admin_register_requests.js
+++ b/mbtb_app/web_portal/mbtb_portal/assets/js/admin_register_requests.js
@@ -10,7 +10,7 @@ $('#accept_request_btn').click(function(e){
   let post_request = $.post( "/approve_user_requests", {requests_ids: requests_ids, email_data: email_data}, function(data, status) {
     if (data === 'approved'){
       // display alert on suceess and reload window
-      alert("Your selected requested are approved.");
+      alert("Your selected requests are approved.");
       location.reload();
     }
     else {
@@ -39,7 +39,7 @@ $('#deny_request_btn').click(function(e){
   var delete_request = $.post( "/deny_user_requests", {requests_ids: requests_ids, email_data: email_data}, function(data, status) {
     if (data === 'completed'){
       // display alert on suceess and reload window
-      alert("Your selected requested are denied.");
+      alert("Your selected requests are denied.");
       location.reload();
     }
     else {

--- a/mbtb_app/web_portal/mbtb_portal/assets/js/admin_tissue_requests.js
+++ b/mbtb_app/web_portal/mbtb_portal/assets/js/admin_tissue_requests.js
@@ -7,7 +7,7 @@ $('#accept_tissue_request_btn').click(function(e){
   let post_request = $.post( "/approve_tissue_requests", {requests_ids: requests_ids}, function(data, status) {
     if (data === 'approved'){
       // display alert on suceess and reload window
-      alert("Your selected requested are approved.");
+      alert("Your selected requests are approved.");
       location.reload();
     }
     else {

--- a/mbtb_app/web_portal/mbtb_portal/assets/js/admin_tissue_requests.js
+++ b/mbtb_app/web_portal/mbtb_portal/assets/js/admin_tissue_requests.js
@@ -6,7 +6,7 @@ $('#accept_tissue_request_btn').click(function(e){
   // patch request for sending request_ids, email_data to controller
   let post_request = $.post( "/approve_tissue_requests", {requests_ids: requests_ids}, function(data, status) {
     if (data === 'approved'){
-      // display alert on suceess and reload window
+      // display alert on success and reload window
       alert("Your selected requests are approved.");
       location.reload();
     }
@@ -21,4 +21,30 @@ $('#accept_tissue_request_btn').click(function(e){
     alert( "Please select at least one request.");
   });
 
+});
+
+// To get id from selected checkbox and send a delete request to remove tissue requests
+$('#delete_tissue_request_btn').click(function(e){
+  if (confirm("This action will delete data. Are you sure?")) {
+    // fetching selected checkbox's id from view
+    var requests_ids = get_checkbox_values();
+
+    // patch request for sending request_ids, email_data to controller
+    var delete_request = $.post( "/delete_tissue_requests", {requests_ids: requests_ids}, function(data, status) {
+      if (data === 'completed'){
+        // display alert on success and reload window
+        alert("Your selected requests are deleted.");
+        location.reload();
+      }
+      else {
+        alert("Something went wrong, Please try again.");
+      }
+
+    });
+
+    // display error msg if no checkbox is selected
+    delete_request.fail(function(status) {
+      alert( "Please select at least one request.");
+    });
+  }
 });

--- a/mbtb_app/web_portal/mbtb_portal/assets/js/admin_tissue_requests.js
+++ b/mbtb_app/web_portal/mbtb_portal/assets/js/admin_tissue_requests.js
@@ -1,0 +1,24 @@
+// To get id from selected checkbox and send a patch request to approve status
+$('#accept_tissue_request_btn').click(function(e){
+  // fetching selected checkbox's id from view
+  let requests_ids = get_checkbox_values();
+
+  // patch request for sending request_ids, email_data to controller
+  let post_request = $.post( "/approve_tissue_requests", {requests_ids: requests_ids}, function(data, status) {
+    if (data === 'approved'){
+      // display alert on suceess and reload window
+      alert("Your selected requested are approved.");
+      location.reload();
+    }
+    else {
+      alert("Something went wrong, Please try again.");
+    }
+
+  });
+
+  // display error msg if no checkbox is selected
+  post_request.fail(function(status) {
+    alert( "Please select at least one request.");
+  });
+
+});

--- a/mbtb_app/web_portal/mbtb_portal/assets/js/admin_view_single_archive_tissue_request.js
+++ b/mbtb_app/web_portal/mbtb_portal/assets/js/admin_view_single_archive_tissue_request.js
@@ -2,11 +2,11 @@ let view_single_archive_tissue_request = angular.module("view_single_archive_tis
 
 view_single_archive_tissue_request.controller("view_single_archive_tissue_request_controller", ['$scope', '$window', '$http', function ($scope, $window, $http) {
 
-  // binding data to angular varible from ejs view
+  // binding data to angular variable from ejs view
   $scope.details = $window.archive_tissue_request_data;
 
   // on-click for approve button
-  $scope.revert_single_tissue_req_button = function () {
+  $scope.revert_single_tissue_req_btn = function () {
 
     let url = '/revert_archive_tissue_requests/';
     let requests_ids = [$scope.details.tissue_requests_id];
@@ -26,8 +26,31 @@ view_single_archive_tissue_request.controller("view_single_archive_tissue_reques
         alert("Something went wrong, Please try again.");
       }
     });
+  };
 
-  }
+  // on-click for delete button
+  $scope.delete_single_archive_tissue_req_btn = function () {
+    if (confirm("This action will delete given archived tissue request. Are you sure?")) {
+      let url = '/delete_archive_tissue_requests/';
+      let requests_ids = [$scope.details.tissue_requests_id];
+
+      // post request to sails controller
+      $http({
+        method: 'POST',
+        url: url,
+        data: {requests_ids: requests_ids},
+      }).then(function successCallback(response) {
+        if (response.data === 'completed') {
+          // display alert on success and redirect window
+          alert("Your selected request is deleted.");
+          $window.location.href = '/get_archive_tissue_requests';
+        }
+        else {
+          alert("Something went wrong, Please try again.");
+        }
+      });
+    }
+  };
 
 }]);
 

--- a/mbtb_app/web_portal/mbtb_portal/assets/js/admin_view_single_archived_tissue_request.js
+++ b/mbtb_app/web_portal/mbtb_portal/assets/js/admin_view_single_archived_tissue_request.js
@@ -1,0 +1,34 @@
+let view_single_archive_tissue_request = angular.module("view_single_archive_tissue_request_app", []);
+
+view_single_archive_tissue_request.controller("view_single_archive_tissue_request_controller", ['$scope', '$window', '$http', function ($scope, $window, $http) {
+
+  // binding data to angular varible from ejs view
+  $scope.details = $window.archive_tissue_request_data;
+
+  // on-click for approve button
+  $scope.revert_single_tissue_req_button = function () {
+
+    let url = '/revert_archive_tissue_requests/';
+    let requests_ids = [$scope.details.tissue_requests_id];
+
+    // post request to sails controller
+    $http({
+      method: 'POST',
+      url: url,
+      data: {requests_ids: requests_ids},
+    }).then(function successCallback(response) {
+      if (response.data === 'approved'){
+        // display alert on success and reload window
+        alert("Your selected request is reverted.");
+        $window.location.href = '/get_archive_tissue_requests';
+      }
+      else {
+        alert("Something went wrong, Please try again.");
+      }
+    });
+
+  }
+
+}]);
+
+

--- a/mbtb_app/web_portal/mbtb_portal/assets/js/admin_view_single_tissue_request.js
+++ b/mbtb_app/web_portal/mbtb_portal/assets/js/admin_view_single_tissue_request.js
@@ -2,11 +2,11 @@ let view_single_tissue_request = angular.module("view_single_tissue_request_app"
 
 view_single_tissue_request.controller("view_single_tissue_request_controller", ['$scope', '$window', '$http', function ($scope, $window, $http) {
 
-  // binding data to angular varible from ejs view
+  // binding data to angular variable from ejs view
   $scope.details = $window.tissue_request_data;
 
   // on-click for approve button
-  $scope.approve_single_tissue_req_button = function () {
+  $scope.approve_single_tissue_req_btn = function () {
 
     let url = '/approve_tissue_requests/';
     let requests_ids = [$scope.details.tissue_requests_id];
@@ -26,8 +26,31 @@ view_single_tissue_request.controller("view_single_tissue_request_controller", [
         alert("Something went wrong, Please try again.");
       }
     });
+  };
 
-  }
+  // on-click for delete button
+  $scope.delete_single_tissue_req_btn = function () {
+    if (confirm("This action will delete data. Are you sure?")) {
+      let url = '/delete_tissue_requests/';
+      let requests_ids = [$scope.details.tissue_requests_id];
+
+      // post request to sails controller
+      $http({
+        method: 'POST',
+        url: url,
+        data: {requests_ids: requests_ids},
+      }).then(function successCallback(response) {
+        if (response.data === 'completed') {
+          // display alert on success and redirect window
+          alert("Your selected request is deleted.");
+          $window.location.href = '/get_new_tissue_requests';
+        }
+        else {
+          alert("Something went wrong, Please try again.");
+        }
+      });
+    }
+    };
 
 }]);
 

--- a/mbtb_app/web_portal/mbtb_portal/assets/js/admin_view_single_tissue_request.js
+++ b/mbtb_app/web_portal/mbtb_portal/assets/js/admin_view_single_tissue_request.js
@@ -18,6 +18,8 @@ view_single_tissue_request.controller("view_single_tissue_request_controller", [
       data: {requests_ids: requests_ids},
     }).then(function successCallback(response) {
       if (response.data === 'approved'){
+        // display alert on success and reload window
+        alert("Your selected request is approved.");
         $window.location.href = '/get_new_tissue_requests';
       }
       else {

--- a/mbtb_app/web_portal/mbtb_portal/assets/js/admin_view_single_tissue_request.js
+++ b/mbtb_app/web_portal/mbtb_portal/assets/js/admin_view_single_tissue_request.js
@@ -1,0 +1,32 @@
+let view_single_tissue_request = angular.module("view_single_tissue_request_app", []);
+
+view_single_tissue_request.controller("view_single_tissue_request_controller", ['$scope', '$window', '$http', function ($scope, $window, $http) {
+
+  // binding data to angular varible from ejs view
+  $scope.details = $window.tissue_request_data;
+
+  // on-click for approve button
+  $scope.approve_single_tissue_req_button = function () {
+
+    let url = '/approve_tissue_requests/';
+    let requests_ids = [$scope.details.tissue_requests_id];
+
+    // post request to sails controller
+    $http({
+      method: 'POST',
+      url: url,
+      data: {requests_ids: requests_ids},
+    }).then(function successCallback(response) {
+      if (response.data === 'approved'){
+        $window.location.href = '/get_new_tissue_requests';
+      }
+      else {
+        alert("Something went wrong, Please try again.");
+      }
+    });
+
+  }
+
+}]);
+
+

--- a/mbtb_app/web_portal/mbtb_portal/assets/js/tissue_requests_form.js
+++ b/mbtb_app/web_portal/mbtb_portal/assets/js/tissue_requests_form.js
@@ -1,0 +1,1 @@
+angular.module('tissue_requests_app', []);

--- a/mbtb_app/web_portal/mbtb_portal/assets/js/view_data_table.js
+++ b/mbtb_app/web_portal/mbtb_portal/assets/js/view_data_table.js
@@ -11,7 +11,7 @@ myApp.controller('view_data_table_controller', ['$scope', '$filter', '$window', 
   // data binding to angular variable
   $scope.gridOptions.data = $window.mbtb_data;
 
-  // for finding unique elemenets in array
+  // for finding unique elements in array
   let unique = (value, index, self) => {
     return self.indexOf(value) === index
   };

--- a/mbtb_app/web_portal/mbtb_portal/assets/js/view_data_table.js
+++ b/mbtb_app/web_portal/mbtb_portal/assets/js/view_data_table.js
@@ -1,6 +1,6 @@
-var myApp = angular.module('view_data_table_app', ['dataGrid', 'pagination']);
+var view_data_table_app = angular.module('view_data_table_app', ['dataGrid', 'pagination']);
 
-myApp.controller('view_data_table_controller', ['$scope', '$filter', '$window', function ($scope, $filter, $window) {
+view_data_table_app.controller('view_data_table_controller', ['$scope', '$filter', '$window', '$http', function ($scope, $filter, $window, $http) {
 
   $scope.gridOptions = {
     data: [],
@@ -97,29 +97,67 @@ myApp.controller('view_data_table_controller', ['$scope', '$filter', '$window', 
     $scope.clear_btn = true; // disable clear button
   };
 
-  // exporting data or filtered data to csv
-  $scope.exportToCsv = function (currentData) {
-    var export_data = [];
-    currentData.forEach(function (item) {
-      export_data.push({
-        'MBTB Code': item.mbtb_code,
-        'Sex': item.sex,
-        'Age': item.age,
-        'Postmortem Interval': item.postmortem_interval,
-        'Time in Fix': item.time_in_fix,
-        'Neuropathological Diagnosis': item.neuro_diagnosis_id,
-        'Tissue Type': item.tissue_type,
-        'Preservation Method': item.preservation_method,
-        'Clinical Diagnosis': item.clinical_diagnosis,
-        'Storage Date': item.storage_year
+
+  // Download csv file function
+  $scope.download_csv_file = function (download_mode){
+
+    let url = '/download_data/';
+    let export_data = [];
+    let payload = [];
+    let filename = 'MBTB Data';
+
+    // post request to sails controller
+    let post_request = function (url, payload, filename) {
+      $http({
+        method: 'POST',
+        url: url,
+        data: payload,
+      }).then(function successCallback(response) {
+        if (response.data.operation === 'completed') {
+
+          // user prompt to download the csv file, here received data is in json
+          JSONToCSVConvertor(response.data.data, filename, true);
+        } else {
+          alert("Something went wrong, Please try again.");
+        }
       });
-    });
-    JSONToCSVConvertor(export_data, 'Export', true);
-  }
+    };
+
+    // validating download mode
+    if (download_mode === 'all'){
+      payload = {
+        download_mode: download_mode
+      };
+      post_request(url, payload, filename);
+    }
+    else if (download_mode === 'filtered'){
+
+      // pushing filtered mbtb_code values in export_data
+      $scope.filtered_data.data.forEach(function (item) {
+        export_data.push({
+          'mbtb_code': item.mbtb_code,
+        });
+      });
+
+      // preparing payload data
+      payload = {
+        download_mode: download_mode,
+        input_mbtb_codes: export_data
+      };
+
+      filename = 'Filtered MBTB data';
+      post_request(url, payload, filename);
+    }
+    else {
+      alert("Something went wrong, please try again.??");
+      $window.location.reload();
+    }
+
+  };
 }]);
 
 // custom filter to find values between range
-myApp.filter('range_filter', function () {
+view_data_table_app.filter('range_filter', function () {
   return function (data, options) {
     // default min and max values are 0 and 1000
     let min_value = parseInt(options.min_value) || 0 ;

--- a/mbtb_app/web_portal/mbtb_portal/assets/js/view_single_record.js
+++ b/mbtb_app/web_portal/mbtb_portal/assets/js/view_single_record.js
@@ -2,7 +2,7 @@ var view_single_record = angular.module("view_single_record_app", []);
 
 view_single_record.controller("view_single_record_controller", ['$scope', '$window', '$http', function ($scope, $window, $http) {
 
-    // binding data to angular varible from ejs view
+    // binding data to angular variable from ejs view
     $scope.details = $window.mbtb_detailed_data;
 
     // on-click for delete button

--- a/mbtb_app/web_portal/mbtb_portal/assets/styles/admin_archive_tissue_requests.less
+++ b/mbtb_app/web_portal/mbtb_portal/assets/styles/admin_archive_tissue_requests.less
@@ -10,13 +10,13 @@
 }
 
 #revert_tissue_request_btn,
-#delete_tissue_request_btn{
+#delete_archive_tissue_request_btn{
   background: #034F53;
   border-color: #034F53;
 }
 
 #revert_tissue_request_btn:hover,
-#delete_tissue_request_btn:hover{
+#delete_archive_tissue_request_btn:hover{
   border-color: #034F53;
   box-shadow: 0 0 8px rgba(3, 79, 83, 1);
   background: white;

--- a/mbtb_app/web_portal/mbtb_portal/assets/styles/admin_archive_tissue_requests.less
+++ b/mbtb_app/web_portal/mbtb_portal/assets/styles/admin_archive_tissue_requests.less
@@ -1,0 +1,24 @@
+.archive_tissue_requests_container{
+  margin-top: 10vh;
+  margin-bottom: 15vh;
+}
+
+#archive_tissue_requests_table{
+  display: block;
+  overflow-x: auto;
+  white-space: nowrap;
+}
+
+#revert_tissue_request_btn,
+#delete_tissue_request_btn{
+  background: #034F53;
+  border-color: #034F53;
+}
+
+#revert_tissue_request_btn:hover,
+#delete_tissue_request_btn:hover{
+  border-color: #034F53;
+  box-shadow: 0 0 8px rgba(3, 79, 83, 1);
+  background: white;
+  color: #034F53;
+}

--- a/mbtb_app/web_portal/mbtb_portal/assets/styles/admin_new_tissue_requests.less
+++ b/mbtb_app/web_portal/mbtb_portal/assets/styles/admin_new_tissue_requests.less
@@ -1,0 +1,22 @@
+.tissue_requests_container{
+  margin-top: 10vh;
+  margin-bottom: 15vh;
+}
+
+#tissue_requests_table{
+  display: block;
+  overflow-x: auto;
+  white-space: nowrap;
+}
+
+#accept_tissue_request_btn{
+  background: #034F53;
+  border-color: #034F53;
+}
+
+#accept_tissue_request_btn:hover{
+  border-color: #034F53;
+  box-shadow: 0 0 8px rgba(3, 79, 83, 1);
+  background: white;
+  color: #034F53;
+}

--- a/mbtb_app/web_portal/mbtb_portal/assets/styles/admin_new_tissue_requests.less
+++ b/mbtb_app/web_portal/mbtb_portal/assets/styles/admin_new_tissue_requests.less
@@ -9,12 +9,14 @@
   white-space: nowrap;
 }
 
-#accept_tissue_request_btn{
+#accept_tissue_request_btn,
+#delete_tissue_request_btn{
   background: #034F53;
   border-color: #034F53;
 }
 
-#accept_tissue_request_btn:hover{
+#accept_tissue_request_btn:hover,
+#delete_tissue_request_btn:hover{
   border-color: #034F53;
   box-shadow: 0 0 8px rgba(3, 79, 83, 1);
   background: white;

--- a/mbtb_app/web_portal/mbtb_portal/assets/styles/importer.less
+++ b/mbtb_app/web_portal/mbtb_portal/assets/styles/importer.less
@@ -23,3 +23,4 @@
 @import "admin_file_upload";
 @import "admin_data_uploading_guide";
 @import "tissue_request_terms";
+@import "tissue_request_form";

--- a/mbtb_app/web_portal/mbtb_portal/assets/styles/importer.less
+++ b/mbtb_app/web_portal/mbtb_portal/assets/styles/importer.less
@@ -24,3 +24,5 @@
 @import "admin_data_uploading_guide";
 @import "tissue_request_terms";
 @import "tissue_request_form";
+@import "admin_new_tissue_requests";
+@import "admin_archive_tissue_requests";

--- a/mbtb_app/web_portal/mbtb_portal/assets/styles/importer.less
+++ b/mbtb_app/web_portal/mbtb_portal/assets/styles/importer.less
@@ -22,3 +22,4 @@
 @import "view_single_record";
 @import "admin_file_upload";
 @import "admin_data_uploading_guide";
+@import "tissue_request_terms";

--- a/mbtb_app/web_portal/mbtb_portal/assets/styles/tissue_request_form.less
+++ b/mbtb_app/web_portal/mbtb_portal/assets/styles/tissue_request_form.less
@@ -1,0 +1,13 @@
+.tissue_request_form_container{
+  margin-top: 5vh;
+  margin-bottom: 10vh;
+}
+
+.h2_heading{
+  color: #034F53;
+}
+textarea[name=source_of_funding]:focus,
+textarea[name=abstract]:focus{
+  border-color: #034F53;
+  box-shadow: 0px 0px 8px rgba(3, 79, 83, 1);
+}

--- a/mbtb_app/web_portal/mbtb_portal/assets/styles/tissue_request_terms.less
+++ b/mbtb_app/web_portal/mbtb_portal/assets/styles/tissue_request_terms.less
@@ -1,0 +1,5 @@
+.tissue_requests_terms_container{
+  margin-top: 5vh;
+  margin-bottom: 25vh;
+  font-size: 15px;
+}

--- a/mbtb_app/web_portal/mbtb_portal/config/custom.js
+++ b/mbtb_app/web_portal/mbtb_portal/config/custom.js
@@ -23,5 +23,6 @@ module.exports.custom = {
   baseUrl: 'http://localhost:1337',
   user_api_url: 'http://127.0.0.1:8000/', // user api url i.e. for user, admin login, register
   data_api_url: 'http://127.0.0.1:9000/', // data api url
+  api_down_error_msg: 'Servers are down, please contact site admin for the help.', // apis are down error message
 
 };

--- a/mbtb_app/web_portal/mbtb_portal/config/env/production.js
+++ b/mbtb_app/web_portal/mbtb_portal/config/env/production.js
@@ -375,6 +375,7 @@ module.exports = {
     internalEmailAddress: 'support@example.com',
     user_api_url: 'https://mbtb-users.herokuapp.com/',
     data_api_url: 'https://mbtb-data.herokuapp.com/',
+    api_down_error_msg: 'Servers are down, please contact site admin for the help.', // apis are down error message
 
     // mailgunDomain: 'mg.example.com',
     // mailgunSecret: 'key-prod_fake_bd32301385130a0bafe030c',

--- a/mbtb_app/web_portal/mbtb_portal/config/routes.js
+++ b/mbtb_app/web_portal/mbtb_portal/config/routes.js
@@ -218,4 +218,11 @@ module.exports.routes = {
     }
   },
 
+  'GET /view_single_tissue_request/:id': {
+    action: 'admin/view-single-tissue-request',
+    locals: {
+      layout: 'layouts/admin_layout'
+    }
+  },
+
 };

--- a/mbtb_app/web_portal/mbtb_portal/config/routes.js
+++ b/mbtb_app/web_portal/mbtb_portal/config/routes.js
@@ -204,4 +204,11 @@ module.exports.routes = {
     }
   },
 
+  'POST /approve_tissue_requests': {
+    action: 'admin/approve-tissue-requests',
+    locals: {
+      layout: 'layouts/admin_layout'
+    }
+  },
+
 };

--- a/mbtb_app/web_portal/mbtb_portal/config/routes.js
+++ b/mbtb_app/web_portal/mbtb_portal/config/routes.js
@@ -232,4 +232,18 @@ module.exports.routes = {
     }
   },
 
+  'POST /delete_tissue_requests': {
+    action: 'admin/delete-tissue-requests',
+    locals: {
+      layout: 'layouts/admin_layout'
+    }
+  },
+
+  'POST /delete_archive_tissue_requests': {
+    action: 'admin/delete-archive-tissue-requests',
+    locals: {
+      layout: 'layouts/admin_layout'
+    }
+  },
+
 };

--- a/mbtb_app/web_portal/mbtb_portal/config/routes.js
+++ b/mbtb_app/web_portal/mbtb_portal/config/routes.js
@@ -211,4 +211,11 @@ module.exports.routes = {
     }
   },
 
+  'POST /revert_archive_tissue_requests': {
+    action: 'admin/revert-archive-tissue-requests',
+    locals: {
+      layout: 'layouts/admin_layout'
+    }
+  },
+
 };

--- a/mbtb_app/web_portal/mbtb_portal/config/routes.js
+++ b/mbtb_app/web_portal/mbtb_portal/config/routes.js
@@ -190,4 +190,11 @@ module.exports.routes = {
     }
   },
 
+  'GET /get_tissue_requests': {
+    action: 'admin/get-tissue-requests',
+    locals: {
+      layout: 'layouts/admin_layout'
+    }
+  },
+
 };

--- a/mbtb_app/web_portal/mbtb_portal/config/routes.js
+++ b/mbtb_app/web_portal/mbtb_portal/config/routes.js
@@ -225,4 +225,11 @@ module.exports.routes = {
     }
   },
 
+  'GET /view_single_archive_tissue_request/:id': {
+    action: 'admin/view-single-archive-tissue-request',
+    locals: {
+      layout: 'layouts/admin_layout'
+    }
+  },
+
 };

--- a/mbtb_app/web_portal/mbtb_portal/config/routes.js
+++ b/mbtb_app/web_portal/mbtb_portal/config/routes.js
@@ -125,14 +125,14 @@ module.exports.routes = {
   },
 
   'GET /file_upload': {
-    action: 'admin/get-file-upload-view',
+    action: 'admin/get-file-upload-add-data-view',
     locals: {
       layout: 'layouts/admin_layout'
     }
   },
 
   'POST /file_upload': {
-    action: 'admin/file-upload',
+    action: 'admin/file-upload-add-data',
     locals: {
       layout: 'layouts/admin_layout'
     }
@@ -161,6 +161,20 @@ module.exports.routes = {
 
   'GET /data_uploading_guide': {
     action: 'admin/data-uploading-guide',
+    locals: {
+      layout: 'layouts/admin_layout'
+    }
+  },
+
+  'GET /edit_file_upload': {
+    action: 'admin/get-file-upload-edit-data-view',
+    locals: {
+      layout: 'layouts/admin_layout'
+    }
+  },
+
+  'POST /edit_file_upload': {
+    action: 'admin/file-upload-edit-data',
     locals: {
       layout: 'layouts/admin_layout'
     }

--- a/mbtb_app/web_portal/mbtb_portal/config/routes.js
+++ b/mbtb_app/web_portal/mbtb_portal/config/routes.js
@@ -246,4 +246,8 @@ module.exports.routes = {
     }
   },
 
+  'POST /download_data': {
+    action: 'common/download-mbtb-data',
+  },
+
 };

--- a/mbtb_app/web_portal/mbtb_portal/config/routes.js
+++ b/mbtb_app/web_portal/mbtb_portal/config/routes.js
@@ -190,8 +190,15 @@ module.exports.routes = {
     }
   },
 
-  'GET /get_tissue_requests': {
+  'GET /get_new_tissue_requests': {
     action: 'admin/get-tissue-requests',
+    locals: {
+      layout: 'layouts/admin_layout'
+    }
+  },
+
+  'GET /get_archive_tissue_requests': {
+    action: 'admin/get-archive-tissue-requests',
     locals: {
       layout: 'layouts/admin_layout'
     }

--- a/mbtb_app/web_portal/mbtb_portal/config/routes.js
+++ b/mbtb_app/web_portal/mbtb_portal/config/routes.js
@@ -30,8 +30,10 @@ module.exports.routes = {
   'GET /view_data': { action: 'user/view-data-table' },
   'GET /logout': { action: 'user/logout'},
   'GET /view_data/:id': {action: 'user/view-single-record'},
-  'GET /tissue_requests': {action: 'user/user-tissue-requests'},
   'GET /view_data_guide': {action: 'user/view-data-guide'},
+  'GET /tissue_requests_terms': {action: 'user/tissue-requests-terms'},
+  'GET /tissue_requests_form': { action: 'user/get-tissue-requests-form'},
+  'POST /tissue_requests_form': { action: 'user/tissue-requests-form'},
 
   // admin views
   'GET /admin': {

--- a/mbtb_app/web_portal/mbtb_portal/config/routes.js
+++ b/mbtb_app/web_portal/mbtb_portal/config/routes.js
@@ -31,6 +31,7 @@ module.exports.routes = {
   'GET /logout': { action: 'user/logout'},
   'GET /view_data/:id': {action: 'user/view-single-record'},
   'GET /tissue_requests': {action: 'user/user-tissue-requests'},
+  'GET /view_data_guide': {action: 'user/view-data-guide'},
 
   // admin views
   'GET /admin': {
@@ -175,6 +176,13 @@ module.exports.routes = {
 
   'POST /edit_file_upload': {
     action: 'admin/file-upload-edit-data',
+    locals: {
+      layout: 'layouts/admin_layout'
+    }
+  },
+
+  'GET /admin_view_data_guide': {
+    action: 'admin/view-data-guide',
     locals: {
       layout: 'layouts/admin_layout'
     }

--- a/mbtb_app/web_portal/mbtb_portal/package-lock.json
+++ b/mbtb_app/web_portal/mbtb_portal/package-lock.json
@@ -2820,6 +2820,11 @@
         }
       }
     },
+    "moment": {
+      "version": "2.24.0",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.24.0.tgz",
+      "integrity": "sha512-bV7f+6l2QigeBBZSM/6yTNq4P2fNpSWj/0e7jQcy87A8e7o2nAfP/34/2ky5Vw4B9S446EtIhodAzkFCcR4dQg=="
+    },
     "ms": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",

--- a/mbtb_app/web_portal/mbtb_portal/package.json
+++ b/mbtb_app/web_portal/mbtb_portal/package.json
@@ -11,6 +11,7 @@
     "generate-password": "^1.4.2",
     "grunt": "1.0.4",
     "jasmine": "^3.5.0",
+    "moment": "^2.24.0",
     "protractor": "^5.4.2",
     "request": "^2.88.0",
     "sails": "^1.2.3",

--- a/mbtb_app/web_portal/mbtb_portal/views/layouts/admin_layout.ejs
+++ b/mbtb_app/web_portal/mbtb_portal/views/layouts/admin_layout.ejs
@@ -109,7 +109,7 @@
 <script src="/js/admin_homepage.js"></script>
 <script src="/js/admin_register_requests.js"></script>
 <script src="/js/admin_tissue_requests.js"></script>
-<script src="/js/admin_view_single_archived_tissue_request.js"></script>
+<script src="/js/admin_view_single_archive_tissue_request.js"></script>
 <script src="/js/admin_view_single_tissue_request.js"></script>
 <script src="/js/tissue_requests_form.js"></script>
 <script src="/js/user_login.js"></script>

--- a/mbtb_app/web_portal/mbtb_portal/views/layouts/admin_layout.ejs
+++ b/mbtb_app/web_portal/mbtb_portal/views/layouts/admin_layout.ejs
@@ -104,6 +104,7 @@
 
 <!--SCRIPTS-->
 <script src="/js/admin_add_new_data.js"></script>
+<script src="/js/admin_archive_tissue_requests.js"></script>
 <script src="/js/admin_edit_data.js"></script>
 <script src="/js/admin_homepage.js"></script>
 <script src="/js/admin_register_requests.js"></script>

--- a/mbtb_app/web_portal/mbtb_portal/views/layouts/admin_layout.ejs
+++ b/mbtb_app/web_portal/mbtb_portal/views/layouts/admin_layout.ejs
@@ -59,8 +59,8 @@
                     <li class="dropdown">
                         <a class="dropdown-toggle" data-toggle="dropdown" href="#">Tissue Requests<span class="caret"></span></a>
                         <ul class="dropdown-menu">
-                            <li><a href="/get_tissue_requests">New Tissue Requests</a></li>
-                            <li><a href="#">Archived Requests</a></li>
+                            <li><a href="/get_new_tissue_requests">New Tissue Requests</a></li>
+                            <li><a href="/get_archive_tissue_requests">Archived Requests</a></li>
                         </ul>
                     </li>
 

--- a/mbtb_app/web_portal/mbtb_portal/views/layouts/admin_layout.ejs
+++ b/mbtb_app/web_portal/mbtb_portal/views/layouts/admin_layout.ejs
@@ -47,7 +47,23 @@
                             <li><a href="/edit_file_upload">Edit Data</a></li>
                         </ul>
                     </li>
-                    <li><a href="/view_new_requests">User Requests</a></li>
+
+                    <li class="dropdown">
+                        <a class="dropdown-toggle" data-toggle="dropdown" href="#">Users<span class="caret"></span></a>
+                        <ul class="dropdown-menu">
+                            <li><a href="/view_new_requests">New Account Requests</a></li>
+                            <li><a href="#">View Current Users</a></li>
+                        </ul>
+                    </li>
+
+                    <li class="dropdown">
+                        <a class="dropdown-toggle" data-toggle="dropdown" href="#">Tissue Requests<span class="caret"></span></a>
+                        <ul class="dropdown-menu">
+                            <li><a href="/get_tissue_requests">New Tissue Requests</a></li>
+                            <li><a href="#">Archived Requests</a></li>
+                        </ul>
+                    </li>
+
                     <li><a href="/admin_faq">FAQ</a></li>
                 </ul>
 

--- a/mbtb_app/web_portal/mbtb_portal/views/layouts/admin_layout.ejs
+++ b/mbtb_app/web_portal/mbtb_portal/views/layouts/admin_layout.ejs
@@ -107,6 +107,7 @@
 <script src="/js/admin_edit_data.js"></script>
 <script src="/js/admin_homepage.js"></script>
 <script src="/js/admin_register_requests.js"></script>
+<script src="/js/admin_tissue_requests.js"></script>
 <script src="/js/tissue_requests_form.js"></script>
 <script src="/js/user_login.js"></script>
 <script src="/js/user_registration.js"></script>

--- a/mbtb_app/web_portal/mbtb_portal/views/layouts/admin_layout.ejs
+++ b/mbtb_app/web_portal/mbtb_portal/views/layouts/admin_layout.ejs
@@ -109,6 +109,7 @@
 <script src="/js/admin_homepage.js"></script>
 <script src="/js/admin_register_requests.js"></script>
 <script src="/js/admin_tissue_requests.js"></script>
+<script src="/js/admin_view_single_archived_tissue_request.js"></script>
 <script src="/js/admin_view_single_tissue_request.js"></script>
 <script src="/js/tissue_requests_form.js"></script>
 <script src="/js/user_login.js"></script>

--- a/mbtb_app/web_portal/mbtb_portal/views/layouts/admin_layout.ejs
+++ b/mbtb_app/web_portal/mbtb_portal/views/layouts/admin_layout.ejs
@@ -91,6 +91,7 @@
 <script src="/js/admin_edit_data.js"></script>
 <script src="/js/admin_homepage.js"></script>
 <script src="/js/admin_register_requests.js"></script>
+<script src="/js/tissue_requests_form.js"></script>
 <script src="/js/user_login.js"></script>
 <script src="/js/user_registration.js"></script>
 <script src="/js/view_data_table.js"></script>

--- a/mbtb_app/web_portal/mbtb_portal/views/layouts/admin_layout.ejs
+++ b/mbtb_app/web_portal/mbtb_portal/views/layouts/admin_layout.ejs
@@ -109,6 +109,7 @@
 <script src="/js/admin_homepage.js"></script>
 <script src="/js/admin_register_requests.js"></script>
 <script src="/js/admin_tissue_requests.js"></script>
+<script src="/js/admin_view_single_tissue_request.js"></script>
 <script src="/js/tissue_requests_form.js"></script>
 <script src="/js/user_login.js"></script>
 <script src="/js/user_registration.js"></script>

--- a/mbtb_app/web_portal/mbtb_portal/views/layouts/admin_layout.ejs
+++ b/mbtb_app/web_portal/mbtb_portal/views/layouts/admin_layout.ejs
@@ -44,6 +44,7 @@
                                 </ul>
                             </li>
                             <li><a href="/admin_view_data">View Data</a></li>
+                            <li><a href="/edit_file_upload">Edit Data</a></li>
                         </ul>
                     </li>
                     <li><a href="/view_new_requests">User Requests</a></li>

--- a/mbtb_app/web_portal/mbtb_portal/views/layouts/layout.ejs
+++ b/mbtb_app/web_portal/mbtb_portal/views/layouts/layout.ejs
@@ -75,6 +75,7 @@
     <script src="/js/admin_homepage.js"></script>
     <script src="/js/admin_register_requests.js"></script>
     <script src="/js/admin_tissue_requests.js"></script>
+    <script src="/js/admin_view_single_archived_tissue_request.js"></script>
     <script src="/js/admin_view_single_tissue_request.js"></script>
     <script src="/js/tissue_requests_form.js"></script>
     <script src="/js/user_login.js"></script>

--- a/mbtb_app/web_portal/mbtb_portal/views/layouts/layout.ejs
+++ b/mbtb_app/web_portal/mbtb_portal/views/layouts/layout.ejs
@@ -70,6 +70,7 @@
 
     <!--SCRIPTS-->
     <script src="/js/admin_add_new_data.js"></script>
+    <script src="/js/admin_archive_tissue_requests.js"></script>
     <script src="/js/admin_edit_data.js"></script>
     <script src="/js/admin_homepage.js"></script>
     <script src="/js/admin_register_requests.js"></script>

--- a/mbtb_app/web_portal/mbtb_portal/views/layouts/layout.ejs
+++ b/mbtb_app/web_portal/mbtb_portal/views/layouts/layout.ejs
@@ -75,7 +75,7 @@
     <script src="/js/admin_homepage.js"></script>
     <script src="/js/admin_register_requests.js"></script>
     <script src="/js/admin_tissue_requests.js"></script>
-    <script src="/js/admin_view_single_archived_tissue_request.js"></script>
+    <script src="/js/admin_view_single_archive_tissue_request.js"></script>
     <script src="/js/admin_view_single_tissue_request.js"></script>
     <script src="/js/tissue_requests_form.js"></script>
     <script src="/js/user_login.js"></script>

--- a/mbtb_app/web_portal/mbtb_portal/views/layouts/layout.ejs
+++ b/mbtb_app/web_portal/mbtb_portal/views/layouts/layout.ejs
@@ -75,6 +75,7 @@
     <script src="/js/admin_homepage.js"></script>
     <script src="/js/admin_register_requests.js"></script>
     <script src="/js/admin_tissue_requests.js"></script>
+    <script src="/js/admin_view_single_tissue_request.js"></script>
     <script src="/js/tissue_requests_form.js"></script>
     <script src="/js/user_login.js"></script>
     <script src="/js/user_registration.js"></script>

--- a/mbtb_app/web_portal/mbtb_portal/views/layouts/layout.ejs
+++ b/mbtb_app/web_portal/mbtb_portal/views/layouts/layout.ejs
@@ -33,7 +33,7 @@
             <ul class="nav navbar-nav">
               <li><a href="/">Home</a></li>
               <li><a href="/view_data">Dataset</a></li>
-              <li><a href="/tissue_requests">Tissue Requests</a></li>
+              <li><a href="/tissue_requests_terms">Tissue Requests</a></li>
               <li><a href="/faq">FAQ</a></li>
             </ul>
 
@@ -73,6 +73,7 @@
     <script src="/js/admin_edit_data.js"></script>
     <script src="/js/admin_homepage.js"></script>
     <script src="/js/admin_register_requests.js"></script>
+    <script src="/js/tissue_requests_form.js"></script>
     <script src="/js/user_login.js"></script>
     <script src="/js/user_registration.js"></script>
     <script src="/js/view_data_table.js"></script>

--- a/mbtb_app/web_portal/mbtb_portal/views/layouts/layout.ejs
+++ b/mbtb_app/web_portal/mbtb_portal/views/layouts/layout.ejs
@@ -73,6 +73,7 @@
     <script src="/js/admin_edit_data.js"></script>
     <script src="/js/admin_homepage.js"></script>
     <script src="/js/admin_register_requests.js"></script>
+    <script src="/js/admin_tissue_requests.js"></script>
     <script src="/js/tissue_requests_form.js"></script>
     <script src="/js/user_login.js"></script>
     <script src="/js/user_registration.js"></script>

--- a/mbtb_app/web_portal/mbtb_portal/views/pages/admin_archive_tissue_requests.ejs
+++ b/mbtb_app/web_portal/mbtb_portal/views/pages/admin_archive_tissue_requests.ejs
@@ -1,7 +1,7 @@
 <title>Tissue Requests</title>
 <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.4.1/jquery.min.js"></script>
 
-<div class="container-fluid requests_container">
+<div class="container-fluid archive_tissue_requests_container">
     <div class="col-md-12">
         <h2 class="heading_title">Archived Tissue Requests</h2>
         <br>
@@ -12,7 +12,7 @@
                 var mbtb_data = <%- JSON.stringify(data) %>;
             </script>
 
-            <table id="user_requests_table" class="table table-bordered">
+            <table id="archive_tissue_requests_table" class="table table-bordered">
                 <thead>
                 <tr>
                     <th><input type="checkbox" onClick="toggle_all(this.checked)" id="select_all"></th>
@@ -55,8 +55,13 @@
             </table>
         </form>
 
-        <div class="text-right">
-            <button class="btn btn-danger" id="deny_tissue_request_btn"> Delete</button>
+        <br>
+        <br>
+        <div class="form-group button_holder">
+            <div class="col" id="cancel_btn">
+                <button class="btn btn-primary" id="revert_tissue_request_btn">Revert</button>
+                <button class="btn btn-primary" id="delete_tissue_request_btn">Delete</button>
+            </div>
         </div>
 
         <div id="temp_msg"></div>

--- a/mbtb_app/web_portal/mbtb_portal/views/pages/admin_archive_tissue_requests.ejs
+++ b/mbtb_app/web_portal/mbtb_portal/views/pages/admin_archive_tissue_requests.ejs
@@ -30,6 +30,8 @@
                     <th data-field="project_title">Project Title</th>
                     <th data-field="source_of_funding">Source of Funding</th>
                     <th data-field="abstract">Abstract</th>
+                    <th data-field="received_date">Received Date</th>
+                    <th data-field="approval_date">Approval Date</th>
                 </tr>
                 </thead>
 
@@ -51,11 +53,13 @@
                         <td data-field="city"><%= data[i].city %></td>
                         <td data-field="province"><%= data[i].province %></td>
                         <td data-field="country"><%= data[i].postal_code %></td>
-                        <td data-field="comments"><%= data[i].phone_number %></td>
-                        <td data-field="position_title"><%= data[i].fax_number %></td>
-                        <td data-field="address_line_1"><%= data[i].project_title %></td>
-                        <td data-field="address_line_2"><%= data[i].source_of_funding %></td>
-                        <td data-field="address_line_2"><%= data[i].abstract %></td>
+                        <td data-field="phone_number"><%= data[i].phone_number %></td>
+                        <td data-field="fax_number"><%= data[i].fax_number %></td>
+                        <td data-field="project_title"><%= data[i].project_title %></td>
+                        <td data-field="source_of_funding"><%= data[i].source_of_funding %></td>
+                        <td data-field="abstract"><%= data[i].abstract %></td>
+                        <td data-field="received_date"><%= data[i].received_date %></td>
+                        <td data-field="approval_date"><%= data[i].approval_date %></td>
                     </tr>
                 <% } %>
             </table>

--- a/mbtb_app/web_portal/mbtb_portal/views/pages/admin_archive_tissue_requests.ejs
+++ b/mbtb_app/web_portal/mbtb_portal/views/pages/admin_archive_tissue_requests.ejs
@@ -32,6 +32,7 @@
                     <th data-field="abstract">Abstract</th>
                     <th data-field="received_date">Received Date</th>
                     <th data-field="approval_date">Approval Date</th>
+                    <th data-field="tissue_request_number">Tissue Request No</th>
                 </tr>
                 </thead>
 
@@ -60,6 +61,7 @@
                         <td data-field="abstract"><%= data[i].abstract %></td>
                         <td data-field="received_date"><%= data[i].received_date %></td>
                         <td data-field="approval_date"><%= data[i].approval_date %></td>
+                        <td data-field="tissue_request_number"><%= data[i].tissue_request_number %></td>
                     </tr>
                 <% } %>
             </table>

--- a/mbtb_app/web_portal/mbtb_portal/views/pages/admin_archive_tissue_requests.ejs
+++ b/mbtb_app/web_portal/mbtb_portal/views/pages/admin_archive_tissue_requests.ejs
@@ -66,7 +66,7 @@
         <div class="form-group button_holder">
             <div class="col" id="cancel_btn">
                 <button class="btn btn-primary" id="revert_tissue_request_btn">Revert</button>
-                <button class="btn btn-primary" id="delete_tissue_request_btn">Delete</button>
+                <button class="btn btn-primary" id="delete_archive_tissue_request_btn">Delete</button>
             </div>
         </div>
 

--- a/mbtb_app/web_portal/mbtb_portal/views/pages/admin_archive_tissue_requests.ejs
+++ b/mbtb_app/web_portal/mbtb_portal/views/pages/admin_archive_tissue_requests.ejs
@@ -35,9 +35,15 @@
 
                 <% for(var i=0; i < data.length; i++) { %>
                     <tr>
-                        <td><input type="checkbox" name="checkbox<%- i %>" id="checkbox<%- i %>" value="<%= data[i].tissue_requests_id %>")></td>
+                        <td>
+                            <input type="checkbox" name="checkbox<%- i %>" id="checkbox<%- i %>" value="<%= data[i].tissue_requests_id %>")>
+                        </td>
                         <td data-field="title"><%= data[i].title %></td>
-                        <td data-field="first_name"><%= data[i].first_name %></td>
+                        <td data-field="first_name">
+                            <a href="/view_single_archive_tissue_request/<%= data[i].tissue_requests_id %>">
+                                <%= data[i].first_name %>
+                            </a>
+                        </td>
                         <td data-field="last_name"><%= data[i].last_name %></td>
                         <td data-field="email"><%= data[i].email %></td>
                         <td data-field="institution"><%= data[i].institution %></td>

--- a/mbtb_app/web_portal/mbtb_portal/views/pages/admin_archive_tissue_requests.ejs
+++ b/mbtb_app/web_portal/mbtb_portal/views/pages/admin_archive_tissue_requests.ejs
@@ -35,7 +35,7 @@
 
                 <% for(var i=0; i < data.length; i++) { %>
                     <tr>
-                        <td><input type="checkbox" name="checkbox<%- i %>" id="checkbox<%- i %>" value="<%= data[i].id %>")></td>
+                        <td><input type="checkbox" name="checkbox<%- i %>" id="checkbox<%- i %>" value="<%= data[i].tissue_requests_id %>")></td>
                         <td data-field="title"><%= data[i].title %></td>
                         <td data-field="first_name"><%= data[i].first_name %></td>
                         <td data-field="last_name"><%= data[i].last_name %></td>

--- a/mbtb_app/web_portal/mbtb_portal/views/pages/admin_archive_tissue_requests.ejs
+++ b/mbtb_app/web_portal/mbtb_portal/views/pages/admin_archive_tissue_requests.ejs
@@ -1,0 +1,68 @@
+<title>Tissue Requests</title>
+<script src="https://ajax.googleapis.com/ajax/libs/jquery/3.4.1/jquery.min.js"></script>
+
+<div class="container-fluid requests_container">
+    <div class="col-md-12">
+        <h2 class="heading_title">Archived Tissue Requests</h2>
+        <br>
+        <form id="user_requests_form" >
+            <input type="hidden" id="data_length" value="<%= data.length %>">
+            <script>
+                // binding data recieved from sails controller to JS variable to pass it to angular
+                var mbtb_data = <%- JSON.stringify(data) %>;
+            </script>
+
+            <table id="user_requests_table" class="table table-bordered">
+                <thead>
+                <tr>
+                    <th><input type="checkbox" onClick="toggle_all(this.checked)" id="select_all"></th>
+                    <th data-field="title">Title</th>
+                    <th data-field="first_name">First Name</th>
+                    <th data-field="last_name">Last Name</th>
+                    <th data-field="email">Email</th>
+                    <th data-field="institution">Institution</th>
+                    <th data-field="department_name">Department</th>
+                    <th data-field="city">City</th>
+                    <th data-field="province">Province</th>
+                    <th data-field="postal_code">Postal/Zip Code</th>
+                    <th data-field="phone_number">Phone</th>
+                    <th data-field="fax_number">Fax</th>
+                    <th data-field="project_title">Project Title</th>
+                    <th data-field="source_of_funding">Source of Funding</th>
+                    <th data-field="abstract">Abstract</th>
+                </tr>
+                </thead>
+
+                <% for(var i=0; i < data.length; i++) { %>
+                    <tr>
+                        <td><input type="checkbox" name="checkbox<%- i %>" id="checkbox<%- i %>" value="<%= data[i].id %>")></td>
+                        <td data-field="title"><%= data[i].title %></td>
+                        <td data-field="first_name"><%= data[i].first_name %></td>
+                        <td data-field="last_name"><%= data[i].last_name %></td>
+                        <td data-field="email"><%= data[i].email %></td>
+                        <td data-field="institution"><%= data[i].institution %></td>
+                        <td data-field="department_name"><%= data[i].department_name %></td>
+                        <td data-field="city"><%= data[i].city %></td>
+                        <td data-field="province"><%= data[i].province %></td>
+                        <td data-field="country"><%= data[i].postal_code %></td>
+                        <td data-field="comments"><%= data[i].phone_number %></td>
+                        <td data-field="position_title"><%= data[i].fax_number %></td>
+                        <td data-field="address_line_1"><%= data[i].project_title %></td>
+                        <td data-field="address_line_2"><%= data[i].source_of_funding %></td>
+                        <td data-field="address_line_2"><%= data[i].abstract %></td>
+                    </tr>
+                <% } %>
+            </table>
+        </form>
+
+        <div class="text-right">
+            <button class="btn btn-danger" id="deny_tissue_request_btn"> Delete</button>
+        </div>
+
+        <div id="temp_msg"></div>
+
+    </div>
+</div>
+<br>
+
+

--- a/mbtb_app/web_portal/mbtb_portal/views/pages/admin_data_uploading_guide.ejs
+++ b/mbtb_app/web_portal/mbtb_portal/views/pages/admin_data_uploading_guide.ejs
@@ -8,26 +8,38 @@
         <br>
         <br>
 
+
         <ul>
-            <li>
-                One file can be uploaded at a time.
-            </li>
-            <li>
-                The maximum file limit for uploading is 500 MB.
-            </li>
-            <li>
-                Only 'CSV' file format is supported. Kindly follow this
-                <a href="https://support.office.com/en-us/article/Import-or-export-text-txt-or-csv-files-5250ac4c-663c-47ce-937b-339e391393ba">link</a>
-                for converting your file into the 'CSV' file.
-            </li>
-            <li>
-                Please make sure the input file matches column names in the given <a href="/files/sample_file.csv">sample file</a>.
-                Also, refer to this <a href="/files/data_upload_reference.xlsx">reference file</a> to know the data type and supported field values.
-            </li>
-            <li>
-                The following fields are mandatory: 'mbtb_code', 'sex', 'storage_year', 'formalin_fixed', 'fresh_frozen'. Other fields can be null.
-                <i>(<strong>Note:</strong> The following fields can be null: 'tissue_type', 'autopsy_type', 'neuropathology_diagnosis' but it is highly recommended to avoid it.)</i>
-            </li>
+            <p>
+                <li>
+                    One file can be uploaded at a time.
+                </li>
+            </p>
+            <p>
+                <li>
+                    The maximum file limit for uploading is 500 MB.
+                </li>
+            </p>
+            <p>
+                <li>
+                    Only 'CSV' file format is supported. Kindly follow this
+                    <a href="https://support.office.com/en-us/article/Import-or-export-text-txt-or-csv-files-5250ac4c-663c-47ce-937b-339e391393ba">link</a>
+                    for converting your file into the 'CSV' file.
+                </li>
+            </p>
+            <p>
+                <li>
+                    Please make sure the input file matches column names in the given <a href="/files/sample_file.csv">sample file</a>.
+                    Also, refer to this <a href="/files/data_upload_reference.xlsx">reference file</a> to know the data type and supported field values.
+                </li>
+            </p>
+            <p>
+                <li>
+                    The following fields are mandatory: 'mbtb_code', 'sex', 'storage_year', 'formalin_fixed', 'fresh_frozen'. Other fields can be null.
+                    <i>(<strong>Note:</strong> The following fields can be null: 'tissue_type', 'autopsy_type', 'neuropathology_diagnosis' but it is highly recommended to avoid it.)</i>
+                </li>
+            </p>
+
         </ul>
     </div>
 </div>

--- a/mbtb_app/web_portal/mbtb_portal/views/pages/admin_faq.ejs
+++ b/mbtb_app/web_portal/mbtb_portal/views/pages/admin_faq.ejs
@@ -18,6 +18,11 @@
                     <a href="/data_uploading_guide">Data Uploading Guide</a>
                 </h4>
             </li>
+            <li>
+                <h4>
+                    <a href="/admin_view_data_guide">View Data Guide</a>
+                </h4>
+            </li>
         </ul>
     </h4>
 </div>

--- a/mbtb_app/web_portal/mbtb_portal/views/pages/admin_file_upload.ejs
+++ b/mbtb_app/web_portal/mbtb_portal/views/pages/admin_file_upload.ejs
@@ -1,10 +1,10 @@
-<title>Admin - Upload File</title>
+<title>Admin - Upload File - <%= data_mode %></title>
 
 <div class="container-fluid file_upload_container">
-    <h2 class="heading_title">File Upload</h2>
+    <h2 class="heading_title">File Upload - <%= data_mode %></h2>
     <br>
 
-    <form id="file_upload_form" action="/file_upload" method="post" enctype="multipart/form-data" novalidate>
+    <form id="file_upload_form" action="<%= url %>" method="post" enctype="multipart/form-data" novalidate>
 
         <label for="file" id="choose_file_label">Choose File:</label>
         <input name="upload_file" type="file" accept="text/csv">

--- a/mbtb_app/web_portal/mbtb_portal/views/pages/admin_file_upload.ejs
+++ b/mbtb_app/web_portal/mbtb_portal/views/pages/admin_file_upload.ejs
@@ -4,10 +4,12 @@
     <h2 class="heading_title">File Upload - <%= data_mode %></h2>
     <br>
 
-    <form id="file_upload_form" action="<%= url %>" method="post" enctype="multipart/form-data" novalidate>
+    <form id="file_upload_form" name="file_upload_form" action="<%= url %>" method="post" enctype="multipart/form-data">
 
-        <label for="file" id="choose_file_label">Choose File:</label>
-        <input name="upload_file" type="file" accept="text/csv" required>
+        <div>
+            <label for="upload_file" id="choose_file_label">Choose File:</label>
+            <input name="upload_file" id="upload_file" type="file" accept="text/csv" required>
+        </div>
 
         <br>
         <br>

--- a/mbtb_app/web_portal/mbtb_portal/views/pages/admin_file_upload.ejs
+++ b/mbtb_app/web_portal/mbtb_portal/views/pages/admin_file_upload.ejs
@@ -7,7 +7,7 @@
     <form id="file_upload_form" action="<%= url %>" method="post" enctype="multipart/form-data" novalidate>
 
         <label for="file" id="choose_file_label">Choose File:</label>
-        <input name="upload_file" type="file" accept="text/csv">
+        <input name="upload_file" type="file" accept="text/csv" required>
 
         <br>
         <br>

--- a/mbtb_app/web_portal/mbtb_portal/views/pages/admin_homepage.ejs
+++ b/mbtb_app/web_portal/mbtb_portal/views/pages/admin_homepage.ejs
@@ -69,13 +69,16 @@
         <div class="row">
             <h2 class="heading_title">Internal Links</h2>
             <div>
+                <a href="/admin_view_data">View Data</a>
+            </div>
+            <div>
                 <a href="/add_new_data">Insert Single Row</a>
             </div>
             <div>
-                <a href="/file_upload">File Upload</a>
+                <a href="/file_upload">File Upload - Add Data</a>
             </div>
             <div>
-                <a href="/admin_view_data">View Data</a>
+                <a href="/edit_file_upload">File Upload - Edit Data</a>
             </div>
             <div>
                 <a href="/view_new_requests">User Requests</a>

--- a/mbtb_app/web_portal/mbtb_portal/views/pages/admin_homepage.ejs
+++ b/mbtb_app/web_portal/mbtb_portal/views/pages/admin_homepage.ejs
@@ -51,7 +51,8 @@
             <h2 class="heading_title">Database Description</h2>
             <p>
                 Research in human brain tissues is essential to understanding the nature and causes of neurologic and psychiatric diseases.
-                The online database provides access to the Maritime Brain Tissue Bank (MBTB) dataset. It aims to enable researchers to explore the MBTB dataset.
+                The online database provides access to the Maritime Brain Tissue Bank (MBTB) dataset.
+                It aims to enable researchers to explore the MBTB dataset and select possible cases for tissue requests.
             </p>
             <p>
                 The dataset contains demographic, relevant clinical history and neuropathological information.
@@ -121,7 +122,8 @@
 
 <div class="container-fluid">
     <i>
-        This website was funded by the <a href="https://www.innovation.ca/">Canada Foundation for Innovation</a>.
+        This website was funded by the <a href="https://www.innovation.ca/">Canada Foundation for Innovation</a> and the
+        Dalhousie Medical Research Foundation's <a href="https://dmrf.ca/molly-appeal/">Molly Appeal for Medical Research</a>.
     </i>
 </div>
 

--- a/mbtb_app/web_portal/mbtb_portal/views/pages/admin_new_tissue_requests.ejs
+++ b/mbtb_app/web_portal/mbtb_portal/views/pages/admin_new_tissue_requests.ejs
@@ -30,6 +30,7 @@
                     <th data-field="project_title">Project Title</th>
                     <th data-field="source_of_funding">Source of Funding</th>
                     <th data-field="abstract">Abstract</th>
+                    <th data-field="received_date">Received Date</th>
                 </tr>
                 </thead>
 
@@ -44,12 +45,13 @@
                         <td data-field="department_name"><%= data[i].department_name %></td>
                         <td data-field="city"><%= data[i].city %></td>
                         <td data-field="province"><%= data[i].province %></td>
-                        <td data-field="country"><%= data[i].postal_code %></td>
-                        <td data-field="comments"><%= data[i].phone_number %></td>
-                        <td data-field="position_title"><%= data[i].fax_number %></td>
-                        <td data-field="address_line_1"><%= data[i].project_title %></td>
-                        <td data-field="address_line_2"><%= data[i].source_of_funding %></td>
-                        <td data-field="address_line_2"><%= data[i].abstract %></td>
+                        <td data-field="postal_code"><%= data[i].postal_code %></td>
+                        <td data-field="phone_number"><%= data[i].phone_number %></td>
+                        <td data-field="fax_number"><%= data[i].fax_number %></td>
+                        <td data-field="project_title"><%= data[i].project_title %></td>
+                        <td data-field="source_of_funding"><%= data[i].source_of_funding %></td>
+                        <td data-field="abstract"><%= data[i].abstract %></td>
+                        <td data-field="received_date"><%= data[i].received_date %></td>
                     </tr>
                 <% } %>
             </table>

--- a/mbtb_app/web_portal/mbtb_portal/views/pages/admin_new_tissue_requests.ejs
+++ b/mbtb_app/web_portal/mbtb_portal/views/pages/admin_new_tissue_requests.ejs
@@ -37,7 +37,7 @@
                     <tr>
                         <td><input type="checkbox" name="checkbox<%- i %>" id="checkbox<%- i %>" value="<%= data[i].tissue_requests_id %>")></td>
                         <td data-field="title"><%= data[i].title %></td>
-                        <td data-field="first_name"><%= data[i].first_name %></td>
+                        <td data-field="first_name"><a href="/view_single_tissue_request/<%= data[i].tissue_requests_id %>"><%= data[i].first_name %></a></td>
                         <td data-field="last_name"><%= data[i].last_name %></td>
                         <td data-field="email"><%= data[i].email %></td>
                         <td data-field="institution"><%= data[i].institution %></td>

--- a/mbtb_app/web_portal/mbtb_portal/views/pages/admin_new_tissue_requests.ejs
+++ b/mbtb_app/web_portal/mbtb_portal/views/pages/admin_new_tissue_requests.ejs
@@ -60,7 +60,7 @@
         <div class="form-group button_holder">
             <div class="col" id="cancel_btn">
                 <button class="btn btn-primary" id="accept_tissue_request_btn">Approve</button>
-                <a href="/admin" class="btn btn_space">Cancel</a>
+                <button class="btn btn-primary" id="delete_tissue_request_btn">Delete</button>
             </div>
         </div>
 

--- a/mbtb_app/web_portal/mbtb_portal/views/pages/admin_new_tissue_requests.ejs
+++ b/mbtb_app/web_portal/mbtb_portal/views/pages/admin_new_tissue_requests.ejs
@@ -31,6 +31,7 @@
                     <th data-field="source_of_funding">Source of Funding</th>
                     <th data-field="abstract">Abstract</th>
                     <th data-field="received_date">Received Date</th>
+                    <th data-field="tissue_request_number">Tissue Request No</th>
                 </tr>
                 </thead>
 
@@ -52,6 +53,7 @@
                         <td data-field="source_of_funding"><%= data[i].source_of_funding %></td>
                         <td data-field="abstract"><%= data[i].abstract %></td>
                         <td data-field="received_date"><%= data[i].received_date %></td>
+                        <td data-field="tissue_request_number"><%= data[i].tissue_request_number %></td>
                     </tr>
                 <% } %>
             </table>

--- a/mbtb_app/web_portal/mbtb_portal/views/pages/admin_new_tissue_requests.ejs
+++ b/mbtb_app/web_portal/mbtb_portal/views/pages/admin_new_tissue_requests.ejs
@@ -1,7 +1,7 @@
 <title>Tissue Requests</title>
 <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.4.1/jquery.min.js"></script>
 
-<div class="container-fluid requests_container">
+<div class="container-fluid tissue_requests_container">
     <div class="col-md-12">
         <h2 class="heading_title">New Tissue Requests</h2>
         <br>
@@ -12,7 +12,7 @@
                 var mbtb_data = <%- JSON.stringify(data) %>;
             </script>
 
-            <table id="user_requests_table" class="table table-bordered">
+            <table id="tissue_requests_table" class="table table-bordered">
                 <thead>
                 <tr>
                     <th><input type="checkbox" onClick="toggle_all(this.checked)" id="select_all"></th>
@@ -55,9 +55,13 @@
             </table>
         </form>
 
-        <div class="text-right">
-            <button class="btn btn-danger" id="deny_tissue_request_btn"> Deny</button>
-            <button class="btn btn-success" id="accept_tissue_request_btn">Approve</button>
+        <br>
+        <br>
+        <div class="form-group button_holder">
+            <div class="col" id="cancel_btn">
+                <button class="btn btn-primary" id="accept_tissue_request_btn">Approve</button>
+                <a href="/admin" class="btn btn_space">Cancel</a>
+            </div>
         </div>
 
         <div id="temp_msg"></div>

--- a/mbtb_app/web_portal/mbtb_portal/views/pages/admin_new_tissue_requests.ejs
+++ b/mbtb_app/web_portal/mbtb_portal/views/pages/admin_new_tissue_requests.ejs
@@ -1,0 +1,69 @@
+<title>Tissue Requests</title>
+<script src="https://ajax.googleapis.com/ajax/libs/jquery/3.4.1/jquery.min.js"></script>
+
+<div class="container-fluid requests_container">
+    <div class="col-md-12">
+        <h2 class="heading_title">New Tissue Requests</h2>
+        <br>
+        <form id="user_requests_form" >
+            <input type="hidden" id="data_length" value="<%= data.length %>">
+            <script>
+                // binding data recieved from sails controller to JS variable to pass it to angular
+                var mbtb_data = <%- JSON.stringify(data) %>;
+            </script>
+
+            <table id="user_requests_table" class="table table-bordered">
+                <thead>
+                <tr>
+                    <th><input type="checkbox" onClick="toggle_all(this.checked)" id="select_all"></th>
+                    <th data-field="title">Title</th>
+                    <th data-field="first_name">First Name</th>
+                    <th data-field="last_name">Last Name</th>
+                    <th data-field="email">Email</th>
+                    <th data-field="institution">Institution</th>
+                    <th data-field="department_name">Department</th>
+                    <th data-field="city">City</th>
+                    <th data-field="province">Province</th>
+                    <th data-field="postal_code">Postal/Zip Code</th>
+                    <th data-field="phone_number">Phone</th>
+                    <th data-field="fax_number">Fax</th>
+                    <th data-field="project_title">Project Title</th>
+                    <th data-field="source_of_funding">Source of Funding</th>
+                    <th data-field="abstract">Abstract</th>
+                </tr>
+                </thead>
+
+                <% for(var i=0; i < data.length; i++) { %>
+                    <tr>
+                        <td><input type="checkbox" name="checkbox<%- i %>" id="checkbox<%- i %>" value="<%= data[i].id %>")></td>
+                        <td data-field="title"><%= data[i].title %></td>
+                        <td data-field="first_name"><%= data[i].first_name %></td>
+                        <td data-field="last_name"><%= data[i].last_name %></td>
+                        <td data-field="email"><%= data[i].email %></td>
+                        <td data-field="institution"><%= data[i].institution %></td>
+                        <td data-field="department_name"><%= data[i].department_name %></td>
+                        <td data-field="city"><%= data[i].city %></td>
+                        <td data-field="province"><%= data[i].province %></td>
+                        <td data-field="country"><%= data[i].postal_code %></td>
+                        <td data-field="comments"><%= data[i].phone_number %></td>
+                        <td data-field="position_title"><%= data[i].fax_number %></td>
+                        <td data-field="address_line_1"><%= data[i].project_title %></td>
+                        <td data-field="address_line_2"><%= data[i].source_of_funding %></td>
+                        <td data-field="address_line_2"><%= data[i].abstract %></td>
+                    </tr>
+                <% } %>
+            </table>
+        </form>
+
+        <div class="text-right">
+            <button class="btn btn-danger" id="deny_tissue_request_btn"> Deny</button>
+            <button class="btn btn-success" id="accept_tissue_request_btn">Approve</button>
+        </div>
+
+        <div id="temp_msg"></div>
+
+    </div>
+</div>
+<br>
+
+

--- a/mbtb_app/web_portal/mbtb_portal/views/pages/admin_new_tissue_requests.ejs
+++ b/mbtb_app/web_portal/mbtb_portal/views/pages/admin_new_tissue_requests.ejs
@@ -35,7 +35,7 @@
 
                 <% for(var i=0; i < data.length; i++) { %>
                     <tr>
-                        <td><input type="checkbox" name="checkbox<%- i %>" id="checkbox<%- i %>" value="<%= data[i].id %>")></td>
+                        <td><input type="checkbox" name="checkbox<%- i %>" id="checkbox<%- i %>" value="<%= data[i].tissue_requests_id %>")></td>
                         <td data-field="title"><%= data[i].title %></td>
                         <td data-field="first_name"><%= data[i].first_name %></td>
                         <td data-field="last_name"><%= data[i].last_name %></td>

--- a/mbtb_app/web_portal/mbtb_portal/views/pages/admin_view_data_table.ejs
+++ b/mbtb_app/web_portal/mbtb_portal/views/pages/admin_view_data_table.ejs
@@ -255,11 +255,11 @@
 
         <div class="row button_holder">
             <div class="col-md-12">
-                <button class="btn btn-primary export_button" ng-click="exportToCsv(gridOptions.data)">Export data to CSV
+                <button class="btn btn-primary export_button" ng-click="download_csv_file('all')">Export data to CSV
                     <i class="fa fa-download"></i>
                 </button>
 
-                <button class="btn btn-primary export_button" ng-click="exportToCsv(filtered_data.data)">Export filtered data to CSV
+                <button class="btn btn-primary export_button" ng-click="download_csv_file('filtered')">Export filtered data to CSV
                     <i class="fa fa-download"></i>
                 </button>
             </div>

--- a/mbtb_app/web_portal/mbtb_portal/views/pages/admin_view_data_table.ejs
+++ b/mbtb_app/web_portal/mbtb_portal/views/pages/admin_view_data_table.ejs
@@ -266,5 +266,13 @@
         </div>
 
     </div>
+    <br>
 
 </div>
+
+<div class="container-fluid">
+    <i>
+        Please refer to the following <a href="/admin_view_data_guide">guide</a> for further reference.
+    </i>
+</div>
+<br><br>

--- a/mbtb_app/web_portal/mbtb_portal/views/pages/admin_view_single_archive_tissue_request.ejs
+++ b/mbtb_app/web_portal/mbtb_portal/views/pages/admin_view_single_archive_tissue_request.ejs
@@ -1,0 +1,116 @@
+<title>View Archived Tissue Request</title>
+<script src="https://ajax.googleapis.com/ajax/libs/jquery/3.4.1/jquery.min.js"></script>
+<script src="https://angular-data-grid.github.io/dist/JSONToCSVConvertor.js"></script>
+<link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.5.0/css/font-awesome.min.css">
+
+
+<div ng-app="view_single_archive_tissue_request_app" ng-controller="view_single_archive_tissue_request_controller"
+     class="container-fluid single_record_container">
+
+    <h2 class="heading_title">View Archived Tissue Request</h2>
+    <br>
+
+    <script>
+        // binding data received from sails controller to JS variable to pass it to angular
+        var archive_tissue_request_data = <%- JSON.stringify(detailed_data) %>;
+    </script>
+
+    <div class="row">
+
+        <div class="col-md-8">
+            <table class="table table-bordered">
+                <thead>
+                <tr class="detailed_data_header">
+                    <th>Parameter</th>
+                    <th>Detail</th>
+                </tr>
+                </thead>
+
+                <tbody >
+                <tr>
+                    <td scope="row" class="col-md-3">Title</td>
+                    <td>{{details.title}}</td>
+                </tr>
+
+                <tr>
+                    <td scope="row">First Name</td>
+                    <td>{{details.first_name}}</td>
+                </tr>
+
+                <tr>
+                    <td scope="row">Last Name</td>
+                    <td>{{details.last_name}}</td>
+                </tr>
+
+                <tr>
+                    <td scope="row">Email</td>
+                    <td>{{details.email}}</td>
+                </tr>
+
+                <tr>
+                    <td scope="row">Institution</td>
+                    <td>{{details.institution}}</td>
+                </tr>
+
+                <tr>
+                    <td scope="row">Department</td>
+                    <td>{{details.department_name}}</td>
+                </tr>
+
+                <tr>
+                    <td scope="row">City</td>
+                    <td>{{details.city}}</td>
+                </tr>
+
+                <tr>
+                    <td scope="row">Province</td>
+                    <td>{{details.province}}</td>
+                </tr>
+
+                <tr>
+                    <td scope="row">Postal/Zip Code</td>
+                    <td>{{details.postal_code}}</td>
+                </tr>
+
+                <tr>
+                    <td scope="row">Phone</td>
+                    <td>{{details.phone_number}}</td>
+                </tr>
+
+                <tr>
+                    <td scope="row">Fax</td>
+                    <td>{{details.fax_number}}</td>
+                </tr>
+
+                <tr>
+                    <td scope="row">Project Title</td>
+                    <td>{{details.project_title}}</td>
+                </tr>
+
+                <tr>
+                    <td scope="row">Source of Funding</td>
+                    <td>{{details.source_of_funding}}</td>
+                </tr>
+
+                <tr>
+                    <td scope="row">Abstract</td>
+                    <td>{{details.abstract}}</td>
+                </tr>
+
+            </table>
+        </div>
+    </div>
+
+    <br>
+    <div class="row container-fluid button_holder">
+        <div class="col-sm-4"></div>
+        <div class="col-sm-4">
+            <button ng-click="revert_single_tissue_req_button()" class="btn btn-primary" id="edit_btn">Revert</button>
+            <button class="btn btn-primary" id="delete_btn">Delete</button>
+        </div>
+    </div>
+
+    <br>
+</div>
+
+

--- a/mbtb_app/web_portal/mbtb_portal/views/pages/admin_view_single_archive_tissue_request.ejs
+++ b/mbtb_app/web_portal/mbtb_portal/views/pages/admin_view_single_archive_tissue_request.ejs
@@ -105,8 +105,8 @@
     <div class="row container-fluid button_holder">
         <div class="col-sm-4"></div>
         <div class="col-sm-4">
-            <button ng-click="revert_single_tissue_req_button()" class="btn btn-primary" id="edit_btn">Revert</button>
-            <button class="btn btn-primary" id="delete_btn">Delete</button>
+            <button ng-click="revert_single_tissue_req_btn()" class="btn btn-primary" id="edit_btn">Revert</button>
+            <button ng-click="delete_single_archive_tissue_req_btn()" class="btn btn-primary" id="delete_btn">Delete</button>
         </div>
     </div>
 

--- a/mbtb_app/web_portal/mbtb_portal/views/pages/admin_view_single_archive_tissue_request.ejs
+++ b/mbtb_app/web_portal/mbtb_portal/views/pages/admin_view_single_archive_tissue_request.ejs
@@ -97,6 +97,21 @@
                     <td>{{details.abstract}}</td>
                 </tr>
 
+                <tr>
+                    <td scope="row">Received Date</td>
+                    <td>{{details.received_date}}</td>
+                </tr>
+
+                <tr>
+                    <td scope="row">Approval Date</td>
+                    <td>{{details.approval_date}}</td>
+                </tr>
+
+                <tr>
+                    <td scope="row">Reverted Date</td>
+                    <td>{{details.reverted_date}}</td>
+                </tr>
+
             </table>
         </div>
     </div>

--- a/mbtb_app/web_portal/mbtb_portal/views/pages/admin_view_single_archive_tissue_request.ejs
+++ b/mbtb_app/web_portal/mbtb_portal/views/pages/admin_view_single_archive_tissue_request.ejs
@@ -28,6 +28,11 @@
 
                 <tbody >
                 <tr>
+                    <td scope="row" class="col-md-3">Tissue Request No</td>
+                    <td>{{details.tissue_request_number}}</td>
+                </tr>
+
+                <tr>
                     <td scope="row" class="col-md-3">Title</td>
                     <td>{{details.title}}</td>
                 </tr>

--- a/mbtb_app/web_portal/mbtb_portal/views/pages/admin_view_single_record.ejs
+++ b/mbtb_app/web_portal/mbtb_portal/views/pages/admin_view_single_record.ejs
@@ -164,8 +164,6 @@
             <a href="/edit_data/{{details.prime_details_id}}/" class="btn btn-primary" id="edit_btn">Edit</a>
             <button ng-click="delete_button()" class="btn btn-primary" id="delete_btn">Delete</button>
         </div>
-
-
     </div>
 
 </div>

--- a/mbtb_app/web_portal/mbtb_portal/views/pages/admin_view_single_tissue_request.ejs
+++ b/mbtb_app/web_portal/mbtb_portal/views/pages/admin_view_single_tissue_request.ejs
@@ -97,6 +97,21 @@
                     <td>{{details.abstract}}</td>
                 </tr>
 
+                <tr>
+                    <td scope="row">Received Date</td>
+                    <td>{{details.received_date}}</td>
+                </tr>
+
+                <tr>
+                    <td scope="row">Approval Date</td>
+                    <td>{{details.approval_date}}</td>
+                </tr>
+
+                <tr>
+                    <td scope="row">Reverted Date</td>
+                    <td>{{details.reverted_date}}</td>
+                </tr>
+
             </table>
         </div>
     </div>

--- a/mbtb_app/web_portal/mbtb_portal/views/pages/admin_view_single_tissue_request.ejs
+++ b/mbtb_app/web_portal/mbtb_portal/views/pages/admin_view_single_tissue_request.ejs
@@ -28,6 +28,11 @@
 
                 <tbody >
                 <tr>
+                    <td scope="row" class="col-md-3">Tissue Request No</td>
+                    <td>{{details.tissue_request_number}}</td>
+                </tr>
+
+                <tr>
                     <td scope="row" class="col-md-3">Title</td>
                     <td>{{details.title}}</td>
                 </tr>

--- a/mbtb_app/web_portal/mbtb_portal/views/pages/admin_view_single_tissue_request.ejs
+++ b/mbtb_app/web_portal/mbtb_portal/views/pages/admin_view_single_tissue_request.ejs
@@ -1,0 +1,116 @@
+<title>View Tissue Request</title>
+<script src="https://ajax.googleapis.com/ajax/libs/jquery/3.4.1/jquery.min.js"></script>
+<script src="https://angular-data-grid.github.io/dist/JSONToCSVConvertor.js"></script>
+<link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.5.0/css/font-awesome.min.css">
+
+
+<div ng-app="view_single_tissue_request_app" ng-controller="view_single_tissue_request_controller"
+     class="container-fluid single_record_container">
+
+    <h2 class="heading_title">View Tissue Request</h2>
+    <br>
+
+    <script>
+        // binding data recieved from sails controller to JS variable to pass it to angular
+        var tissue_request_data = <%- JSON.stringify(detailed_data) %>;
+    </script>
+
+    <div class="row">
+
+        <div class="col-md-8">
+            <table class="table table-bordered">
+                <thead>
+                <tr class="detailed_data_header">
+                    <th>Parameter</th>
+                    <th>Detail</th>
+                </tr>
+                </thead>
+
+                <tbody >
+                <tr>
+                    <td scope="row" class="col-md-3">Title</td>
+                    <td>{{details.title}}</td>
+                </tr>
+
+                <tr>
+                    <td scope="row">First Name</td>
+                    <td>{{details.first_name}}</td>
+                </tr>
+
+                <tr>
+                    <td scope="row">Last Name</td>
+                    <td>{{details.last_name}}</td>
+                </tr>
+
+                <tr>
+                    <td scope="row">Email</td>
+                    <td>{{details.email}}</td>
+                </tr>
+
+                <tr>
+                    <td scope="row">Institution</td>
+                    <td>{{details.institution}}</td>
+                </tr>
+
+                <tr>
+                    <td scope="row">Department</td>
+                    <td>{{details.department_name}}</td>
+                </tr>
+
+                <tr>
+                    <td scope="row">City</td>
+                    <td>{{details.city}}</td>
+                </tr>
+
+                <tr>
+                    <td scope="row">Province</td>
+                    <td>{{details.province}}</td>
+                </tr>
+
+                <tr>
+                    <td scope="row">Postal/Zip Code</td>
+                    <td>{{details.postal_code}}</td>
+                </tr>
+
+                <tr>
+                    <td scope="row">Phone</td>
+                    <td>{{details.phone_number}}</td>
+                </tr>
+
+                <tr>
+                    <td scope="row">Fax</td>
+                    <td>{{details.fax_number}}</td>
+                </tr>
+
+                <tr>
+                    <td scope="row">Project Title</td>
+                    <td>{{details.project_title}}</td>
+                </tr>
+
+                <tr>
+                    <td scope="row">Source of Funding</td>
+                    <td>{{details.source_of_funding}}</td>
+                </tr>
+
+                <tr>
+                    <td scope="row">Abstract</td>
+                    <td>{{details.abstract}}</td>
+                </tr>
+
+            </table>
+        </div>
+    </div>
+
+    <br>
+    <div class="row container-fluid button_holder">
+        <div class="col-sm-4"></div>
+        <div class="col-sm-4">
+            <button ng-click="approve_single_tissue_req_button()" class="btn btn-primary" id="edit_btn">Approve</button>
+            <button class="btn btn-primary" id="delete_btn">Delete</button>
+        </div>
+    </div>
+
+    <br>
+</div>
+
+

--- a/mbtb_app/web_portal/mbtb_portal/views/pages/admin_view_single_tissue_request.ejs
+++ b/mbtb_app/web_portal/mbtb_portal/views/pages/admin_view_single_tissue_request.ejs
@@ -105,8 +105,8 @@
     <div class="row container-fluid button_holder">
         <div class="col-sm-4"></div>
         <div class="col-sm-4">
-            <button ng-click="approve_single_tissue_req_button()" class="btn btn-primary" id="edit_btn">Approve</button>
-            <button class="btn btn-primary" id="delete_btn">Delete</button>
+            <button ng-click="approve_single_tissue_req_btn()" class="btn btn-primary" id="edit_btn">Approve</button>
+            <button ng-click="delete_single_tissue_req_btn()" class="btn btn-primary" id="edit_btn">Delete</button>
         </div>
     </div>
 

--- a/mbtb_app/web_portal/mbtb_portal/views/pages/faq.ejs
+++ b/mbtb_app/web_portal/mbtb_portal/views/pages/faq.ejs
@@ -13,6 +13,11 @@
                     <a href="/terms">Terms of use</a>
                 </h4>
             </li>
+            <li>
+                <h4>
+                    <a href="/view_data_guide">View Data Guide</a>
+                </h4>
+            </li>
         </ul>
     </h4>
 </div>

--- a/mbtb_app/web_portal/mbtb_portal/views/pages/homepage.ejs
+++ b/mbtb_app/web_portal/mbtb_portal/views/pages/homepage.ejs
@@ -50,7 +50,8 @@
       <h2 class="heading_title">Database Description</h2>
         <p>
           Research in human brain tissues is essential to understanding the nature and causes of neurologic and psychiatric diseases.
-          The online database provides access to the Maritime Brain Tissue Bank (MBTB) dataset. It aims to enable researchers to explore the MBTB dataset.
+          The online database provides access to the Maritime Brain Tissue Bank (MBTB) dataset.
+          It aims to enable researchers to explore the MBTB dataset and select possible cases for tissue requests.
         </p>
         <p>
           The dataset contains demographic, relevant clinical history and neuropathological information.
@@ -101,7 +102,8 @@
 
 <div class="container-fluid">
   <i>
-    This website was funded by the <a href="https://www.innovation.ca/">Canada Foundation for Innovation</a>.
+    This website was funded by the <a href="https://www.innovation.ca/">Canada Foundation for Innovation</a> and the
+    Dalhousie Medical Research Foundation's <a href="https://dmrf.ca/molly-appeal/">Molly Appeal for Medical Research</a>.
   </i>
 </div>
 

--- a/mbtb_app/web_portal/mbtb_portal/views/pages/tissue_request_terms.ejs
+++ b/mbtb_app/web_portal/mbtb_portal/views/pages/tissue_request_terms.ejs
@@ -1,0 +1,40 @@
+<title>Tissue Requests</title>
+<div class="container-fluid tissue_requests_terms_container" >
+    <h2 class="heading_title" id="message_title">Tissue Requests</h2>
+    <br>
+
+    <p>
+        All requests undergo a review process. Upon approval, the tissue requested will be shipped to your laboratory as soon as conveniently possible.
+        The cost of shipping will be assumed by the recipient. There is also a $75/hr cost recovery fee.
+    </p>
+
+    <p>
+        Please download the tissue request template and enter the required information for your selected cases, including MBTB code, neuropathological diagnosis, age, sex and preservation method (formalin fixed or fresh frozen).
+        For each case, please indicate which region(s) of the tissue you are requesting.
+        In the appropriate column, please indicate the size of tissue (cm x cm x cm) for formalin fixed tissue or weight (g) for fresh frozen.
+    </p>
+
+    <p>
+        Once the complete tissue request application has been received, MBTB staff will confirm case and brain region availability.
+    </p>
+
+    <p>
+        The MBTB does not knowingly distribute unknown infectious specimens. The MBTB, however, does not guarantee that any of the donors of specimens were not exposed to or infected by potentially transmissible infectious agents.
+        Ultimately, it is the responsibility of the recipient investigator to ensure that all their laboratory staff practice safe techniques in handling specimens.
+    </p>
+
+    <p>
+        <i>
+            By clicking on proceed button, I have read all terms and conditions.
+        </i>
+    </p>
+    <br>
+    <div class="row container-fluid button_holder">
+        <div class="col-sm-4"></div>
+        <div class="col-sm-4">
+            <a href="/" class="btn btn-primary" id="edit_btn">Proceed</a>
+            <a href="/" class="btn btn_space">Cancel</a>
+        </div>
+    </div>
+
+</div>

--- a/mbtb_app/web_portal/mbtb_portal/views/pages/tissue_requests_form.ejs
+++ b/mbtb_app/web_portal/mbtb_portal/views/pages/tissue_requests_form.ejs
@@ -1,0 +1,182 @@
+<title>Tissue Requests</title>
+
+<div class="container-fluid tissue_request_form_container">
+
+    <div class="row">
+        <div class="col-md-auto">
+            <h2 class="h2_heading">Tissue Requests</h2>
+        </div>
+    </div>
+    <br>
+    <br>
+    <div ng-app="tissue_requests_app" ng-cloak="">
+        <form class="form-horizontal" name="tissue_requests_form" action="/tissue_requests_form" method="post" novalidate>
+
+            <div class="form-group row">
+                <label class="col-sm-4 control-label">Title</label>
+                <div class="col-sm-5">
+                    <input class="form-control" name="title" type="text">
+                </div>
+            </div>
+
+            <div class="form-group row"
+                 ng-class="{ 'has-error' : tissue_requests_form.first_name.$invalid && !tissue_requests_form.first_name.$pristine }">
+                <label class="col-sm-4 control-label">* First Name</label>
+                <div class="col-sm-5">
+                    <input class="form-control" name="first_name" type="text" ng-model="first_name" required="">
+                </div>
+                <div ng-show="tissue_requests_form.first_name.$dirty && tissue_requests_form.first_name.$error.required" class="help-block">
+                    This field is required
+                </div>
+            </div>
+
+            <div class="form-group row"
+                 ng-class="{ 'has-error' : tissue_requests_form.last_name.$invalid && !tissue_requests_form.last_name.$pristine }">
+                <label class="col-sm-4 control-label">* Last Name</label>
+                <div class="col-sm-5">
+                    <input class="form-control" name="last_name" type="text" ng-model="last_name" required="">
+                </div>
+                <div ng-show="tissue_requests_form.last_name.$dirty && tissue_requests_form.last_name.$error.required" class="help-block">
+                    This field is required
+                </div>
+            </div>
+
+            <div class="form-group row"
+                 ng-class="{ 'has-error' : tissue_requests_form.email.$invalid && !tissue_requests_form.email.$pristine }">
+                <label class="col-sm-4 control-label">* Email</label>
+                <div class="col-sm-5">
+                    <input class="form-control" name="email" type="email" ng-model="email" required="" ng-pattern = "/^.+@.+\..+$/">
+                </div>
+                <div class="error_msg help-block"
+                     ng-show="tissue_requests_form.email.$dirty && tissue_requests_form.email.$invalid">
+                    <div ng-message-exp="['required', 'pattern']">
+                        Your email must be between 10 and 100 characters long and look like an e-mail address.
+                    </div>
+                </div>
+            </div>
+
+            <div class="form-group row"
+                 ng-class="{ 'has-error' : tissue_requests_form.institution.$invalid && !tissue_requests_form.institution.$pristine }">
+                <label class="col-sm-4 control-label">* Institution</label>
+                <div class="col-sm-5">
+                    <input class="form-control" name="institution" type="text" ng-model="institution" required="">
+                </div>
+                <div ng-show="tissue_requests_form.institution.$dirty && tissue_requests_form.institution.$error.required" class="help-block">
+                    This field is required
+                </div>
+            </div>
+
+            <div class="form-group row"
+                 ng-class="{ 'has-error' : tissue_requests_form.department_name.$invalid && !tissue_requests_form.department_name.$pristine }">
+                <label class="col-sm-4 control-label">* Department</label>
+                <div class="col-sm-5">
+                    <input class="form-control" name="department_name" type="text" ng-model="department_name" required="">
+                </div>
+                <div ng-show="tissue_requests_form.department_name.$dirty && tissue_requests_form.department_name.$error.required" class="help-block">
+                    This field is required
+                </div>
+            </div>
+
+            <div class="form-group row"
+                 ng-class="{ 'has-error' : tissue_requests_form.city.$invalid && !tissue_requests_form.city.$pristine }">
+                <label class="col-sm-4 control-label">* City</label>
+                <div class="col-sm-5">
+                    <input class="form-control" name="city" type="text" ng-model="city" required="">
+                </div>
+                <div ng-show="tissue_requests_form.city.$dirty && tissue_requests_form.city.$error.required" class="help-block">
+                    This field is required
+                </div>
+            </div>
+
+            <div class="form-group row"
+                 ng-class="{ 'has-error' : tissue_requests_form.province.$invalid && !tissue_requests_form.province.$pristine }">
+                <label class="col-sm-4 control-label">* Province</label>
+                <div class="col-sm-5">
+                    <input class="form-control" name="province" type="text" ng-model="province" required="">
+                </div>
+                <div ng-show="tissue_requests_form.province.$dirty && tissue_requests_form.province.$error.required" class="help-block">
+                    This field is required
+                </div>
+            </div>
+
+            <div class="form-group row"
+                 ng-class="{ 'has-error' : tissue_requests_form.postal_code.$invalid && !tissue_requests_form.postal_code.$pristine }">
+                <label class="col-sm-4 control-label">* Postal/Zip Code</label>
+                <div class="col-sm-5">
+                    <input class="form-control" name="postal_code" type="text" ng-model="postal_code" required="">
+                </div>
+                <div ng-show="tissue_requests_form.postal_code.$dirty && tissue_requests_form.postal_code.$error.required" class="help-block">
+                    This field is required
+                </div>
+            </div>
+
+            <div class="form-group row">
+                <label class="col-sm-4 control-label">Phone</label>
+                <div class="col-sm-5">
+                    <input class="form-control" name="phone_number" type="text">
+                </div>
+            </div>
+
+            <div class="form-group row">
+                <label class="col-sm-4 control-label">Fax</label>
+                <div class="col-sm-5">
+                    <input class="form-control" name="fax_number" type="text">
+                </div>
+            </div>
+
+            <div class="form-group row"
+                 ng-class="{ 'has-error' : tissue_requests_form.project_title.$invalid && !tissue_requests_form.project_title.$pristine }">
+                <label class="col-sm-4 control-label">* Project Title</label>
+                <div class="col-sm-5">
+                    <input class="form-control" name="project_title" type="text" ng-model="project_title" required="">
+                </div>
+                <div ng-show="tissue_requests_form.project_title.$dirty && tissue_requests_form.project_title.$error.required" class="help-block">
+                    This field is required
+                </div>
+            </div>
+
+            <div class="form-group row"
+                 ng-class="{ 'has-error' : tissue_requests_form.source_of_funding.$invalid && !tissue_requests_form.source_of_funding.$pristine }">
+                <label class="col-sm-4 control-label">* Source of Funding</label>
+                <div class="col-sm-5">
+                    <textarea class="form-control" name="source_of_funding" rows="2" ng-model="source_of_funding" required=""></textarea>
+                </div>
+                <div ng-show="tissue_requests_form.source_of_funding.$dirty && tissue_requests_form.source_of_funding.$error.required" class="help-block">
+                    This field is required
+                </div>
+            </div>
+
+            <div class="form-group row"
+                 ng-class="{ 'has-error' : tissue_requests_form.abstract.$invalid && !tissue_requests_form.abstract.$pristine }">
+                <label class="col-sm-4 control-label">* Abstract</label>
+                <div class="col-sm-5">
+                    <textarea class="form-control" name="abstract" rows="3" ng-model="abstract" required=""></textarea>
+                </div>
+                <div ng-show="tissue_requests_form.abstract.$dirty && tissue_requests_form.abstract.$error.required" class="help-block">
+                    This field is required
+                </div>
+            </div>
+
+            <div class="form-group row">
+                <div class="col-sm-4 control-label"></div>
+                <div class="col-sm-5">
+                    <input class="form-check-input" type="checkbox" id="agree_terms_checkbox" name="agree_terms_checkbox" ng-model="agree_terms_checkbox" required="true" >
+                    I have reall all terms and conditions
+                    <div ng-show="tissue_requests_form.agree_terms_checkbox.$error.required"></div>
+                </div>
+            </div>
+
+            <div class="form-group row button_holder">
+                <div class="col">
+                    <br>
+                    <button type="submit" class="btn btn-primary" id="submit_btn" ng-disabled="tissue_requests_form.$invalid">Submit</button>
+                </div>
+                <div class="col" id="cancel_btn">
+                    <br>
+                    <a href="/">Cancel</a>
+                </div>
+            </div>
+
+        </form>
+    </div>
+</div>

--- a/mbtb_app/web_portal/mbtb_portal/views/pages/tissue_requests_terms.ejs
+++ b/mbtb_app/web_portal/mbtb_portal/views/pages/tissue_requests_terms.ejs
@@ -32,7 +32,7 @@
     <div class="row container-fluid button_holder">
         <div class="col-sm-4"></div>
         <div class="col-sm-4">
-            <a href="/" class="btn btn-primary" id="edit_btn">Proceed</a>
+            <a href="/tissue_requests_form" class="btn btn-primary" id="edit_btn">Proceed</a>
             <a href="/" class="btn btn_space">Cancel</a>
         </div>
     </div>

--- a/mbtb_app/web_portal/mbtb_portal/views/pages/view_data_guide.ejs
+++ b/mbtb_app/web_portal/mbtb_portal/views/pages/view_data_guide.ejs
@@ -1,0 +1,25 @@
+<title>View Data Guide</title>
+<div class="container-fluid data_guide_container">
+    <h2 class="heading_title">View Data Guide</h2>
+    <br>
+
+    <div class="data_guide_content">
+        <br>
+
+        <ul>
+            <p>
+            <li>
+                Once the dataset has been filtered according to your requirements, please download the csv file.
+                Depending on your research criteria and if your study involves more than one diagnosis, it may be necessary to generate multiple csv files.
+            </li>
+            </p>
+            <p>
+            <li>
+                The detailed records for each case can be viewed by clicking on the MBTB Code.
+                Please remove cases from the csv file that do not match your criteria.
+            </li>
+            </p>
+
+        </ul>
+    </div>
+</div>

--- a/mbtb_app/web_portal/mbtb_portal/views/pages/view_data_table.ejs
+++ b/mbtb_app/web_portal/mbtb_portal/views/pages/view_data_table.ejs
@@ -259,3 +259,10 @@
     </div>
 
 </div>
+
+<div class="container-fluid">
+    <i>
+        Please refer to the following <a href="/view_data_guide">guide</a> for further reference.
+    </i>
+</div>
+<br><br>

--- a/mbtb_app/web_portal/mbtb_portal/views/pages/view_data_table.ejs
+++ b/mbtb_app/web_portal/mbtb_portal/views/pages/view_data_table.ejs
@@ -246,11 +246,11 @@
 
         <div class="row button_holder">
             <div class="col-md-12">
-                <button class="btn btn-primary export_button" ng-click="exportToCsv(gridOptions.data)">Export data to CSV
+                <button class="btn btn-primary export_button" ng-click="download_csv_file('all')">Export data to CSV
                     <i class="fa fa-download"></i>
                 </button>
 
-                <button class="btn btn-primary export_button" ng-click="exportToCsv(filtered_data.data)">Export filtered data to CSV
+                <button class="btn btn-primary export_button" ng-click="download_csv_file('filtered')">Export filtered data to CSV
                     <i class="fa fa-download"></i>
                 </button>
             </div>


### PR DESCRIPTION
## Summary for changes
1. A user can post new tissue requests.
2. Admin can view, approve, delete new requests.
3. Admin can view approved requests in the archived section, can revert or delete them.
4. Modified download data features: added extra fields in download all data, filtered data. Also, refactored data API and sails app for it.
5. #51 fixed.
6. Updated schema with `tissue_request` table.
7. Edit data upload via file